### PR TITLE
repositories: Add sihnon overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4264,6 +4264,19 @@ FIN
     <feed>https://github.com/SFTtech/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>sihnon</name>
+    <description lang="en"><![CDATA[optiz0r's sihnon overlay]]></description>
+    <homepage>https://github.com/optiz0r/gentoo-overlay.git</homepage>
+    <owner type="person">
+      <email>optiz0r@gmail.com</email>
+      <name>optiz0r</name>
+    </owner>
+    <source type="git">https://github.com/optiz0r/gentoo-overlay.git</source>
+    <source type="git">git://github.com/optiz0r/gentoo-overlay.git</source>
+    <source type="git">git@github.com:optiz0r/gentoo-overlay.git</source>
+    <feed>https://github.com/optiz0r/gentoo-overlay/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>silmano</name>
     <description lang="en"><![CDATA[Peter's personal overlay]]></description>
     <homepage>https://cgit.gentoo.org/user/silmano.git/</homepage>


### PR DESCRIPTION
Please add the sihnon overlay. This backs some of the Sabayon Community Repositories (https://sabayon.github.io/community-website/) so would be nice to have it available via layman.