### PR TITLE
repositories: Rename fedora overlay to rpm

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1518,16 +1518,6 @@ FIN
     <feed>https://github.com/farmboy0/portage-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>fedora</name>
-    <description lang="en">Overlay for RPM packagers targeting Fedora, EPEL, CentOS and similar distros</description>
-    <homepage>https://github.com/pavlix/gentoo-fedora</homepage>
-    <owner type="person">
-      <email>pavlix@pavlix.net</email>
-      <name>Pavel Šimerda</name>
-    </owner>
-    <source type="git">https://github.com/pavlix/gentoo-fedora.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>fidonet</name>
     <description lang="en">Overlay of Benny Pedersen</description>
     <owner type="person">
@@ -4018,6 +4008,16 @@ FIN
       <name>Michał Ziąbkowski</name>
     </owner>
     <source type="git">https://gitlab.com/roslin-uberlay/roslin.git</source>
+  </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>rpm</name>
+    <description lang="en">Overlay for RPM packagers targeting Fedora, EPEL, CentOS and similar distros</description>
+    <homepage>https://github.com/pavlix/gentoo-rpm</homepage>
+    <owner type="person">
+      <email>pavlix@pavlix.net</email>
+      <name>Pavel Šimerda</name>
+    </owner>
+    <source type="git">https://github.com/pavlix/gentoo-rpm.git</source>
   </repo>
   <repo quality="experimental" status="official">
     <name>R_Overlay</name>


### PR DESCRIPTION
The overlay has recently been extended to contain `centpkg`, a tool to
access the main CentOS package repository. More tools for more RPM based
distributions are coming and therefore it makes sense to rename the
`fedora` overlay to `rpm`.
