### PR TITLE
repositories: Added seadep-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5603,5 +5603,18 @@ FIN
     <source type="git">git@github.com:ArsenShnurkov/shnurise.git</source>
     <feed>https://github.com/ArsenShnurkov/shnurise/commits/master.atom</feed>
   </repo>
+    <repo quality="experimental" status="unofficial">
+    <name>seadep</name>
+    <description lang="en">just a few ebuilds, I couldn't find elsewhere</description>
+    <homepage>https://github.com/Keepco/gentoo-overlay-seadep</homepage>
+    <owner type="person">
+      <email>Rasmus.thomsen@live.de</email>
+      <name>Rasmus Thomsen</name>
+    </owner>
+    <source type="git">https://github.com/Keepco/gentoo-overlay-seadep.git</source>
+    <source type="git">git://github.com/Keepco/gentoo-overlay-seadep.git</source>
+    <source type="git">git@github.com:Keepco/gentoo-overlay-seadep.git</source>
+    <feed>https://github.com/Keepco/gentoo-overlay-seadep/commits/master.atom</feed>
+  </repo>
   <!-- vim:se et sw=2 ts=2 sts=2 :-->
 </repositories>


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=603144