### PR TITLE
repositories: Add chrisadr overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -819,6 +819,18 @@ FIN
     <feed>https://github.com/feeds/chaoskagami/commits/chaos-overlay/master</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>chrisadr</name>
+    <description lang="en">ChrisADR's personal overlay</description>
+    <homepage>https://github.com/ChrisADR/chrisadr-overlay</homepage>
+    <owner type="person">
+      <email>chrisadr@gentoo.org</email>
+      <name>Christopher Díaz Riveros</name>
+    </owner>
+    <source type="git">https://github.com/ChrisADR/chrisadr-overlay.git</source>
+    <source type="git">git@github.com:ChrisADR/chrisadr-overlay.git</source>
+    <feed>https://github.com/ChrisADR/chrisadr-overlay/commits/master.atom</feed>
+  </repo>
+ <repo quality="experimental" status="unofficial">
     <name>chrytoo</name>
     <description lang="en">Personal overlay for packages that usually aren't in the official repository...</description>
     <homepage>https://github.com/chrytoo/gentoo-overlay</homepage>


### PR DESCRIPTION
No Bugzilla report opened. I want to add my own overlay to be able to keep track of packages that I want to co-maintain without changing portage official tree.

Thanks