### PR TITLE
Add overlays andrey_utkin and decent-im

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -315,6 +315,18 @@ FIN
     </owner>
     <source type="git">https://github.com/andjscott/overlays.git</source>
   </repo>
+  <repo quality="experimental" status="official">
+    <name>andrey_utkin</name>
+    <description lang="en">Developer overlay</description>
+    <homepage>https://github.com/andrey-utkin/gentoo-overlay.git</homepage>
+    <owner type="person">
+      <email>andrey_utkin@gentoo.org</email>
+      <name>andrey_utkin</name>
+    </owner>
+    <source type="git">https://github.com/andrey-utkin/gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/andrey-utkin/gentoo-overlay.git</source>
+    <feed>https://github.com/andrey-utkin/gentoo-overlay/commits/master.atom</feed>
+  </repo>
   <repo quality="experimental" status="unofficial">
     <name>anomen</name>
     <description lang="en">anomen's personal Gentoo overlay</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -990,6 +990,18 @@ FIN
     <feed>https://github.com/damex/deadbeef-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>decent-im</name>
+    <description lang="en">XMPP software overlay maintained by decent.im</description>
+    <homepage>https://github.com/decent-im/gentoo-overlay</homepage>
+    <owner type="person">
+      <email>andrey_utkin@gentoo.org</email>
+      <name>Andrey Utkin</name>
+    </owner>
+    <source type="git">https://github.com/decent-im/gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/decent-im/gentoo-overlay.git</source>
+    <feed>https://github.com/decent-im/gentoo-overlay/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>deepin</name>
     <description lang="en">Gentoo Overlay for Deepin Desktop Environment</description>
     <homepage>https://github.com/zhtengw/deepin-overlay</homepage>


### PR DESCRIPTION
Hi, I'm fresh Gentoo dev and would like to have these overlays registered.

`decent-im` is related to my project of advanced XMPP server deployment. Has few now-obsolete ebuilds which will be cleaned up soon. Has some unique ebuilds, currently gajim from upstream git master is the only case I remember of.

`andrey_utkin` is for any random ebuild I want to host out of main tree. Currently empty.

I couldn't validate XML because the command suggested by [Wiki](https://wiki.gentoo.org/wiki/Project:Overlays/Overlays_guide) failed:

```
 $ xmllint --noout --schema $(portageq get_repo_path / gentoo)/metadata/xml-schema/repositories.xsd repositories.xml
warning: failed to load external entity "/usr/portage/metadata/xml-schema/repositories.xsd"
Schemas parser error : Failed to locate the main schema resource at '/usr/portage/metadata/xml-schema/repositories.xsd'.
WXS schema /usr/portage/metadata/xml-schema/repositories.xsd failed to compile
warning: failed to load external entity "repositories.xml"
```

I am not sure how to resolve this. I hope CI will validate it.

Thanks in advance.