### PR TITLE
repositories: Add frr-gentoo

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1689,6 +1689,18 @@ FIN
     <source type="git">git@github.com:FrostyX/gentoo-overlay.git</source>
     <feed>https://github.com/FrostyX/gentoo-overlay/commits/master.atom</feed>
   </repo>
+  <repo quality="stable" status="official">
+    <name>frr-gentoo</name>
+    <description lang="en">Free Range Routing Gentoo Overlay</description>
+    <homepage>https://frrouting.org/</homepage>
+    <owner type="person">
+      <email>f0o@devilcode.org</email>
+      <name>Daniel 'f0o' Preussker</name>
+    </owner>
+    <source type="git">https://github.com/FRRouting/gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com:FRRouting/gentoo-overlay.git</source>
+    <feed>https://github.com/FRRouting/gentoo-overlay/commits/master.atom</feed>
+  </repo>
   <repo quality="experimental" status="unofficial">
     <name>furikake</name>
     <description lang="en">Gentoo overlay of Alex Wilson</description>


### PR DESCRIPTION
I wish to add frr-gentoo to the official overlay lists.

It contains official (stable and live) ebuilds for free range routing and rtrlib.