### PR TITLE
repositories: Add gentoo-clang overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1830,6 +1830,19 @@ FIN
     <feed>https://cgit.gentoo.org/repo/gentoo.git/atom/</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>gentoo-clang</name>
+    <description lang="en">Gentoo overlay providing patches to build entire system with clang</description>
+    <homepage>https://github.com/BilyakA/gentoo-clang</homepage>
+    <owner type="person">
+      <email>bilyak.alexander@gmail.com</email>
+      <name>Alexander Bilyak</name>
+    </owner>
+    <source type="git">https://github.com/BilyakA/gentoo-clang.git</source>
+    <source type="git">git://github.com/BilyakA/gentoo-clang.git</source>
+    <source type="git">git@github.com:BilyakA/gentoo-clang.git</source>
+    <feed>https://github.com/BilyakA/gentoo-clang/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>gentoo-crypto</name>
     <description>Gentoo overlay for cryptocurrencies</description>
     <homepage>https://github.com/gentoo-crypto/gentoo-crypto-overlay</homepage>


### PR DESCRIPTION
Yet another overlay. This time with patches for building world with clang