### PR TITLE
Update URLs for fritteli overlay, bug #654928

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1691,6 +1691,19 @@ FIN
     <feed>https://github.com/alphallc/freeswitch/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>fritteli</name>
+    <description lang="en">fritteli's Gentoo Overlay</description>
+    <homepage>https://gittr.ch/linux/gentoo-overlay</homepage>
+    <owner type="person">
+      <email>manuel@fritteli.ch</email>
+      <name>Manuel Friedli</name>
+    </owner>
+    <source type="git">https://gittr.ch/linux/gentoo-overlay.git</source>
+    <source type="git">git://gittr.ch/linux/gentoo-overlay.git</source>
+    <source type="git">git@gittr.ch:linux/gentoo-overlay.git</source>
+    <feed>https://gittr.ch/linux/gentoo-overlay.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>frostyx</name>
     <description lang="en">FrostyX's personal overlay</description>
     <homepage>http://frostyx.cz/</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1685,15 +1685,14 @@ FIN
   <repo quality="experimental" status="unofficial">
     <name>fritteli</name>
     <description lang="en">fritteli's Gentoo Overlay</description>
-    <homepage>https://gittr.ch/linux/gentoo-overlay</homepage>
+    <homepage>https://github.com/fritteli/gentoo-overlay</homepage>
     <owner type="person">
       <email>manuel@fritteli.ch</email>
       <name>Manuel Friedli</name>
     </owner>
-    <source type="git">https://gittr.ch/linux/gentoo-overlay.git</source>
-    <source type="git">git://gittr.ch/linux/gentoo-overlay.git</source>
-    <source type="git">git@gittr.ch:linux/gentoo-overlay.git</source>
-    <feed>https://gittr.ch/linux/gentoo-overlay.atom</feed>
+    <source type="git">https://github.com/fritteli/gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/fritteli/gentoo-overlay.git</source>
+    <feed>https://github.com/fritteli/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>frostyx</name>


### PR DESCRIPTION
As per gentoo bug 654928 (https://bugs.gentoo.org/654928), the fritteli overlay is unreachable. This PR changes the URLs from gittr.ch to github.com.