### PR TITLE
Changed repository url for glicOne overlay.

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1955,14 +1955,14 @@ FIN
   <repo quality="experimental" status="unofficial">
     <name>glicOne</name>
     <description lang="en">glicOne Overlay with non existing in layman utils</description>
-    <homepage>https://github.com/RomaniukVadim/glicOne</homepage>
+    <homepage>https://gitlab.com/glicOne/glicOne-overlay</homepage>
     <owner type="person">
-      <email>lavadimka1997@gmail.com</email>
+      <email>romaniuk.cv@gmail.com</email>
       <name>Vadim Romaniuk</name>
     </owner>
-    <source type="git">git://github.com/RomaniukVadim/glicOne-overlay.git</source>
-    <source type="git">https://github.com/RomaniukVadim/glicOne-overlay.git</source>
-    <source type="git">git@github.com:RomaniukVadim/glicOne-overlay.git</source>
+    <source type="git">git://gitlab.com/glicOne/glicOne-overlay.git</source>
+    <source type="git">https://gitlab.com/glicOne/glicOne-overlay.git</source>
+    <source type="git">git@gitlab.com:glicOne/glicOne-overlay.git</source>
     <feed>http://github.com/RomaniukVadim/glicOne-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="official">


### PR DESCRIPTION
Moved to gitlab and changed links to repository