### PR TITLE
repositories: Add zjpxshade overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5445,6 +5445,18 @@ FIN
     <feed>https://github.com/yurijmikhalevich/yurij-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>zjpxshade</name>
+    <description lang="en">zjpxshade's ricerlay</description>
+    <homepage>https://github.com/zjpxshade/gentoo-zjpxshade</homepage>
+    <owner type="person">
+      <email>zjpxshade@gmail.com</email>
+      <name>Zach Pearson</name>
+    </owner>
+    <source type="git">https://github.com/zjpxshade/gentoo-zjpxshade.git</source>
+    <source type="git">git@github.com:zjpxshade/gentoo-zjpxshade.git</source>
+    <feed>https://github.com/zjpxshade/gentoo-zjpxshade/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>zoobab</name>
     <description lang="en">Personal overlay of Benjamin Henrion</description>
     <homepage>https://github.com/zoobab/overlay4gentoo/</homepage>


### PR DESCRIPTION
Planning on adding all the usual ricer programs that are not in the upstream repos (pywal, oomox, etc). I am /very/ new to development, so if there are issues I'm eager to hear about and fix them. 