### PR TITLE
repositories: Add what4-java

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5144,6 +5144,16 @@
     <source type="git">https://github.com/whiledev/whiledev-overlay.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>what4-java</name>
+    <description>Incubator for dev-java updates that the Gentoo Java team has no time for</description>
+    <homepage>https://github.com/kwhat/gentoo-what4-java-overlay</homepage>
+    <owner type="person">
+      <email>alex@1stleg.com</email>
+      <name>Alex Barker</name>
+    </owner>
+    <source type="git">https://github.com/kwhat/gentoo-what4-java-overlay.git</source>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>wichtounet</name>
     <description lang="en">Personal overlay of Baptiste Wicht</description>
     <homepage>https://github.com/wichtounet/wichtounet-overlay</homepage>


### PR DESCRIPTION
Ant 1.9.13 & 1.10.5 as well as other dev-java related items that gentoo java devs do not have time for like ivy 2.4.0.