### PR TITLE
Re-add rust overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4033,6 +4033,19 @@
     <feed>https://github.com/Atoms/rukruk/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>rust</name>
+    <description lang="en">rust modules and tools</description>
+    <homepage>https://github.com/gentoo/gentoo-rust</homepage>
+    <owner type="project">
+      <email>rust@gentoo.org</email>
+      <name>Rust Team</name>
+    </owner>
+    <source type="git">https://github.com/gentoo/gentoo-rust.git</source>
+    <source type="git">git://github.com/gentoo/gentoo-rust.git</source>
+    <source type="git">git@github.com:gentoo/gentoo-rust.git</source>
+    <feed>https://github.com/gentoo/gentoo-rust/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>rwald</name>
     <description lang="en">Personal overlay of Randall Wald</description>
     <homepage>https://cgit.gentoo.org/user/rwald.git/</homepage>


### PR DESCRIPTION
There was some problem with bad ebuild name: https://github.com/gentoo/gentoo-rust/commit/24b4a2539088e85ba1b2013a46ef4ac60edd6ef2
Overlay was removed by that commit previously: https://github.com/gentoo/api-gentoo-org/commit/84ea5ba335fc0bf9bace55c0f292e5cef3902dfb