### PR TITLE
remove gyakovlev overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2100,18 +2100,6 @@
     <feed>https://github.com/uleysky/gsview-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>gyakovlev</name>
-    <description lang="en">User overlay</description>
-    <homepage>https://github.com/gyakovlev/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>ya@sysdump.net</email>
-      <name>Georgy Yakovlev</name>
-    </owner>
-    <source type="git">https://github.com/gyakovlev/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/gyakovlev/gentoo-overlay.git</source>
-    <feed>https://github.com/gyakovlev/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>haarp</name>
     <description lang="en">misc ebuilds that aren't in the main tree</description>
     <homepage>https://cgit.gentoo.org/user/haarp.git/</homepage>


### PR DESCRIPTION
I'm no longer actively working on it
This reverts commit 56b51a8f1403359d04b56b7818d990192e9ae094.