### PR TITLE
Update didactic-duck owner email

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1103,7 +1103,7 @@
     <description>Some ebuilds that might work</description>
     <homepage>https://github.com/lucianposton/didactic-duck</homepage>
     <owner type="person">
-      <email>lucian.poston@gmail.com</email>
+      <email>lucianposton@pm.me</email>
       <name>Lucian Poston</name>
     </owner>
     <source type="git">https://github.com/lucianposton/didactic-duck.git</source>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/669108