### PR TITLE
Adjust the contact email for the atom overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -465,7 +465,7 @@
     <description lang="en">Atom Overlay</description>
     <homepage>https://github.com/elprans/atom-overlay</homepage>
     <owner type="person">
-      <email>elprans@gmail.com</email>
+      <email>elvis@magic.io</email>
       <name>Elvis Pranskevichus</name>
     </owner>
     <source type="git">https://github.com/elprans/atom-overlay.git</source>


### PR DESCRIPTION
This is to match the Bugzilla account email