### PR TITLE
repositories: Add aeon-gentoo-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -138,6 +138,18 @@
     <!-- <feed>https://cgit.gentoo.org/user/activehome.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>aeon-gentoo-overlay</name>
+    <description lang="en">Gentoo overlay for Aeon Dev packages and dependencies</description>
+    <homepage>https://github.com/aeon-engine/aeon-gentoo-overlay</homepage>
+    <owner type="person">
+      <email>robindegen@gmail.com</email>
+      <name>Robin Degen</name>
+    </owner>
+    <source type="git">https://github.com/aeon-engine/aeon-gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/aeon-engine/aeon-gentoo-overlay.git</source>
+    <feed>https://github.com/aeon-engine/aeon-gentoo-overlay/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>ag-ops</name>
     <description lang="en">Useful tools for SysAdmins or DevOps</description>
     <homepage>https://gitlab.com/ILMostro/ag-ops</homepage>


### PR DESCRIPTION
Request to add the aeon-gentoo-overlay. This is an overlay for the development of the opensource Aeon Engine and its support libraries.