### PR TITLE
repositories: Update holgersson-overlay source

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2192,7 +2192,7 @@
       <email>holgersson@posteo.de</email>
       <name>Nils Freydank</name>
     </owner>
-    <source type="git">https://git.holgersson.xyz/holgersson-overlay</source>
+    <source type="git">https://git.holgersson.xyz/foss/holgersson-overlay</source>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>hossie</name>


### PR DESCRIPTION
I’d like to change my overlay's soure URI after my migration to gitea with users and projects.