### PR TITLE
uid-gid.txt: GID/UID 334 for OpenDKIM

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -186,6 +186,7 @@ spire			271	271	acct
 plugdev			-	272	acct
 openntpd		321	321	requested
 amavis			333	333	requested
+opendkim		334	334	requested
 dnscrypt-proxy		353	353	acct
 slurm			400	400	acct
 guest			405	-	historical	Removed from baselayout in [r889](https://sources.gentoo.org/cgi-bin/viewvc.cgi/baselayout/trunk/share.Linux/passwd?limit_changes=0&r1=286&r2=889&pathrev=2545)


### PR DESCRIPTION
See [RFC](https://archives.gentoo.org/gentoo-dev/message/6de44bcdfb6766fedddc45eede347e0c) and OpenDKIM [QA pull request](https://github.com/gentoo/gentoo/pull/13029).
