### PR TITLE
repositories: Add usenet-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5272,5 +5272,18 @@
     <source type="git">https://github.com/comio/plex-overlay.git</source>
     <feed>https://github.com/comio/plex-overlay/commits/master.atom</feed>
   </repo>
+    <repo quality="experimental" status="unofficial">
+      <name>usenet-overlay</name>
+      <description lang="en">Personal Overlay for Lidarr, Radarr and Sonarr </description>
+      <homepage>https://github.com/xartin/gentoo-overlay</homepage>
+      <owner type="person">
+        <email>mcrawford@eliteitminds.com</email>
+        <name>Michael Crawford</name>
+      </owner>
+      <source type="git">https://github.com/xartin/gentoo-overlay.git</source>
+      <source type="git">git+ssh://git@github.com/xartin/gentoo-overlay.git</source>
+      <feed>https://github.com/xartin/gentoo-overlay/commits/master.atom</feed>
+    </repo>
   <!-- vim:se et sw=2 ts=2 sts=2 :-->
 </repositories>
+


### PR DESCRIPTION
Please add my repository "usenet-overlay" to the list of repositories.

After many years i've been learning more advanced git usage so i hope everything is in order. My repo passes repoman QA and has been updated to provide  repositories.xml