### PR TITLE
Add ppfeufer-gentoo-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5308,6 +5308,18 @@
     <source type="git">git+ssh://git@github.com/nelsongraca/gentoo-overlay.git</source>
     <feed>https://github.com/nelsongraca/gentoo-overlay/commits/master.atom</feed>
   </repo>
+      <repo quality="experimental" status="unofficial">
+      <name>ppfeufer-gentoo-overlay</name>
+      <description lang="en">ppfeufer's personal overlay.</description>
+      <homepage>https://github.com/ppfeufer/gentoo-overlay</homepage>
+      <owner type="person">
+        <email>info@ppfeufer.de</email>
+        <name>Peter Pfeufer</name>
+      </owner>
+      <source type="git">https://github.com/ppfeufer/gentoo-overlay.git</source>
+      <source type="git">git+ssh://git@github.com/ppfeufer/gentoo-overlay.git</source>
+      <feed>https://github.com/ppfeufer/gentoo-overlay/commits/master.atom</feed>
+    </repo>
   <!-- vim:se et sw=2 ts=2 sts=2 :-->
 </repositories>
 


### PR DESCRIPTION
Hello there,

I humbly request to add my little overlay.

It currently contains ebuilds for the Enpass password manager and the GitKraken Git Management GUI.

Thank you very much.

Regards
ppfeufer