### PR TITLE
uid-gid.txt: reserve GID/UID 438 for milter-regex

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -211,6 +211,7 @@ slurm			400	400	acct
 guest			405	-	historical	Removed from baselayout in [r889](https://sources.gentoo.org/cgi-bin/viewvc.cgi/baselayout/trunk/share.Linux/passwd?limit_changes=0&r1=286&r2=889&pathrev=2545)
 utmp			-	406	acct
 utmp			-	406	baselayout
+milter-regex		438	438	requested
 ldap			439	439	user.eclass
 collectd		440	440	requested
 firebird		450	450	user.eclass


### PR DESCRIPTION
As discussed on the gentoo-dev mailing list. See also [this pull request](https://github.com/gentoo/gentoo/pull/13964).