### PR TITLE
uid-gid.txt: request 476 UID+GID for stubby (used by net-dns/getdns)

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -225,6 +225,7 @@ mogilefs		460	-	user.eclass
 xrootd			469	469	requested
 i2pd			470	470	acct
 i2p			471	471	acct
+stubby			476	476	requested	Used by net-dns/getdns
 suricata		477	477	acct
 graylog			478	478	acct
 openrct2		479	479	acct


### PR DESCRIPTION
See [this pull request](https://github.com/gentoo/gentoo/pull/14085) and [QA bug report](https://bugs.gentoo.org/694832)