### PR TITLE
uid-gid.txt: acct-*/automx2 added the Gentoo tree

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -216,7 +216,7 @@ slurm			400	400	acct
 guest			405	-	historical	Removed from baselayout in [r889](https://sources.gentoo.org/cgi-bin/viewvc.cgi/baselayout/trunk/share.Linux/passwd?limit_changes=0&r1=286&r2=889&pathrev=2545)
 utmp			-	406	acct
 utmp			-	406	baselayout
-automx2			437	437	requested
+automx2			437	437	acct
 milter-regex		438	438	acct
 ldap			439	439	user.eclass
 collectd		440	440	requested


### PR DESCRIPTION
www-servers/automx2 has been added to the Gentoo tree, along with the acct-*/automx2 packages.