### PR TITLE
uid-git.txt: claim 337 UID+GID for spamd

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -217,6 +217,7 @@ amavis			333	333	requested
 opendkim		334	334	acct
 epmd			335	335	acct
 sqlgrey			336	336	acct
+spamd			337	337	acct
 stunnel			341	341	acct
 dnscrypt-proxy		353	353	acct
 slurm			400	400	acct


### PR DESCRIPTION
Related:  https://github.com/gentoo/gentoo/pull/14055
Signed-off-by: Philippe Chaintreuil <gentoo_bugs_peep@parallaxshift.com>