### PR TITLE
repositories: megacoffee changed to git and new URL (#716374)

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2844,9 +2844,8 @@
       <email>gentoo-overlay@megacoffee.net</email>
       <name>MegaCoffee</name>
     </owner>
-    <source type="mercurial">https://rhodecode.megacoffee.net/gentoo-overlay/main</source>
-    <source type="mercurial">http://rhodecode.megacoffee.net/gentoo-overlay/main</source>
-    <feed>https://rhodecode.megacoffee.net/gentoo-overlay/main/feed/atom</feed>
+    <source type="git">https://gitlab.megacoffee.net/gentoo-overlay/megacoffee-overlay.git</source>
+    <feed>https://gitlab.megacoffee.net/gentoo-overlay/megacoffee-overlay/-/commits/master?format=atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>menelkir</name>


### PR DESCRIPTION
See https://bugs.gentoo.org/716374

Additional to pulling the request you may have to reset your Github mirror; the old Mercurial repository will continue to be served but is incompatible from now on.