### PR TITLE
uid-git.txt: reserve 395 UID+GID for media-video/motion user

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -236,6 +236,7 @@ stunnel			341	341	acct
 dnscrypt-proxy		353	353	acct
 octoprint		368	368	acct
 openvpn		394	394	acct
+motion		395	395	requested     used by media-video/motion
 slurm			400	400	acct
 guest			405	-	historical	Removed from baselayout in [r889](https://sources.gentoo.org/cgi-bin/viewvc.cgi/baselayout/trunk/share.Linux/passwd?limit_changes=0&r1=286&r2=889&pathrev=2545)
 utmp			-	406	acct


### PR DESCRIPTION
The user for media-video/motion should be registered in uid-git.txt,
as per GLEP-81 and comments on pull request https://github.com/gentoo/gentoo/pull/15513

modified:   uid-gid.txt
Signed-off-by: Johannes Willem Fernhout <hfern@fernhout.info>
