### PR TITLE
uid-gid.txt: claim 100 for sndiod

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -142,6 +142,7 @@ dovecot			97	97	user.eclass
 input			-	97	acct
 input			-	97	baselayout
 maradns			99	99	user.eclass
+sndiod			100	-	acct
 users			-	100	baselayout
 users			-	100	baselayout-fbsd
 messagebus		101	101	acct


### PR DESCRIPTION
OpenBSD (where sndio is from) uses 99, which is claimed, so picked the next id.