### PR TITLE
 Fix https protocol attributes

### DIFF
--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -13,7 +13,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     <mirror>
       <name>University of Waterloo</name>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.csclub.uwaterloo.ca/gentoo-distfiles</uri>
     </mirror>
@@ -26,12 +26,12 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="North America" country="US" countryname="USA">
     <mirror>
       <name>OSU Open Source Lab (Corvallis; New York; Chicago)</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://gentoo.osuosl.org/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://gentoo.osuosl.org/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://gentoo.osuosl.org/</uri>
     </mirror>
     <mirror>
       <name>LeaseWeb (Anycast: San Francisco; Dallas; Washington, D.C.; Miami)</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.leaseweb.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.leaseweb.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.leaseweb.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.leaseweb.com/gentoo/</uri>
     </mirror>
@@ -46,26 +46,26 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Massachusetts Institute of Technology</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirrors.mit.edu/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirrors.mit.edu/gentoo-distfiles/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirrors.mit.edu/gentoo-distfiles/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirrors.mit.edu/gentoo-distfiles/</uri>
     </mirror>
     <mirror>
       <name>Rochester Institute of Technology</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.rit.edu/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirrors.rit.edu/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirrors.rit.edu/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirrors.rit.edu/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirrors.rit.edu/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Rackspace Technology</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirror.rackspace.com/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Clarkson University</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.clarkson.edu/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.clarkson.edu/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.clarkson.edu/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.clarkson.edu/gentoo/</uri>
     </mirror>
@@ -73,7 +73,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="South America" country="BR" countryname="Brazil">
     <mirror>
       <name>C3SL, Federal University of Paraná</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://gentoo.c3sl.ufpr.br/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://gentoo.c3sl.ufpr.br/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://gentoo.c3sl.ufpr.br/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://gentoo.c3sl.ufpr.br/gentoo/</uri>
     </mirror>
@@ -85,7 +85,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="BE" countryname="Belgium">
     <mirror>
       <name>Belnet</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.belnet.be/pub/rsync.gentoo.org/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.belnet.be/pub/rsync.gentoo.org/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.belnet.be/pub/rsync.gentoo.org/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.belnet.be/gentoo/gentoo/</uri>
     </mirror>
@@ -97,7 +97,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="CH" countryname="Switzerland">
     <mirror>
       <name>Init7</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.init7.net/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.init7.net/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.init7.net/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.init7.net/gentoo/</uri>
     </mirror>
@@ -116,14 +116,14 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>UPC Česká republika, a.s.</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.dkm.cz/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.dkm.cz/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.dkm.cz/gentoo/</uri>
     </mirror>
   </mirrorgroup>
   <mirrorgroup region="Europe" country="DK" countryname="Denmark">
     <mirror>
       <name>dotsrc.org</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.dotsrc.org/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirrors.dotsrc.org/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirrors.dotsrc.org/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirrors.dotsrc.org/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirrors.dotsrc.org/gentoo/</uri>
@@ -141,13 +141,13 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Ircam</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.ircam.fr/pub/gentoo-distfiles/</uri>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.ircam.fr/pub/gentoo-distfiles/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirrors.ircam.fr/pub/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirrors.ircam.fr/pub/gentoo-distfiles/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirrors.ircam.fr/pub/gentoo-distfiles/</uri>
     </mirror>
     <mirror>
       <name>soeasyto.com</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.soeasyto.com/distfiles.gentoo.org/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirrors.soeasyto.com/distfiles.gentoo.org/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirrors.soeasyto.com/distfiles.gentoo.org/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirrors.soeasyto.com/distfiles.gentoo.org/</uri>
     </mirror>
@@ -155,20 +155,20 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="DE" countryname="Germany">
     <mirror>
       <name>LeaseWeb (Anycast: Frankfurt)</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.leaseweb.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.leaseweb.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.leaseweb.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.leaseweb.com/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Ruhr-Universität Bochum</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://linux.rz.ruhr-uni-bochum.de/gentoo-mirror/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://linux.rz.ruhr-uni-bochum.de/gentoo</uri>
     </mirror>
     <mirror>
       <name>Uni Erlangen-Nürnberg</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.fau.de/gentoo</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.fau.de/gentoo</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.fau.de/gentoo</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.fau.de/gentoo</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.fau.de/gentoo</uri>
@@ -181,70 +181,70 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>University of Applied Sciences, Esslingen</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp-stud.hs-esslingen.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>1&amp;1 Internet SE</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.eu.oneandone.net/linux/distributions/gentoo/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.eu.oneandone.net/linux/distributions/gentoo/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.eu.oneandone.net/linux/distributions/gentoo/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.eu.oneandone.net/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Netcologne</name>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirror.netcologne.de/gentoo/</uri>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.netcologne.de/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.netcologne.de/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.netcologne.de/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.netcologne.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>RWTH Aachen University</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.halifax.rwth-aachen.de/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.halifax.rwth-aachen.de/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.halifax.rwth-aachen.de/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.halifax.rwth-aachen.de/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.halifax.rwth-aachen.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.gwdg.de/pub/linux/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.gwdg.de/pub/linux/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.gwdg.de/pub/linux/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.gwdg.de/pub/linux/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.gwdg.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>TU Ilmenau</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.tu-ilmenau.de/mirror/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.tu-ilmenau.de/mirror/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.tu-ilmenau.de/mirror/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.tu-ilmenau.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Leibniz Universität Hannover</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp.uni-hannover.de/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://ftp.uni-hannover.de/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp.uni-hannover.de/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://ftp.uni-hannover.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Ostbayerische Technische Hochschule Regensburg</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://packages.hs-regensburg.de/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://packages.hs-regensburg.de/gentoo-distfiles/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://packages.hs-regensburg.de/gentoo-distfiles/</uri>
     </mirror>
     <mirror>
       <name>Universität Stuttgart</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.uni-stuttgart.de/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.uni-stuttgart.de/gentoo-distfiles/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.uni-stuttgart.de/gentoo-distfiles/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.uni-stuttgart.de/gentoo-distfiles/</uri>
     </mirror>
     <mirror>
       <name>Freie Universität Berlin - Spline</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp.spline.inf.fu-berlin.de/mirrors/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://ftp.spline.inf.fu-berlin.de/mirrors/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp.spline.inf.fu-berlin.de/mirrors/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp.spline.inf.fu-berlin.de/gentoo-distfiles/</uri>
     </mirror>
     <mirror>
       <name>Netzwerge GmbH</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.netzwerge.de/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.netzwerge.de/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.netzwerge.de/gentoo/</uri>
     </mirror>
   </mirrorgroup>
@@ -258,7 +258,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="HU" countryname="Hungary">
     <mirror>
       <name>Free Software Network Hungary</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp.fsn.hu/mirrors/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://ftp.fsn.hu/mirrors/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp.fsn.hu/mirrors/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://ftp.fsn.hu/mirrors/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp.fsn.hu/linux/gentoo/</uri>
@@ -267,7 +267,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="IT" countryname="Italy">
     <mirror>
       <name>GARR</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://gentoo.mirror.garr.it/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://gentoo.mirror.garr.it/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://gentoo.mirror.garr.it/</uri>
     </mirror>
   </mirrorgroup>
@@ -287,14 +287,14 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="NL" countryname="Netherlands">
     <mirror>
       <name>Universiteit Twente</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.snt.utwente.nl/pub/os/linux/gentoo</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.snt.utwente.nl/pub/os/linux/gentoo</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.snt.utwente.nl/pub/os/linux/gentoo</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.snt.utwente.nl/pub/os/linux/gentoo</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.snt.utwente.nl/gentoo</uri>
     </mirror>
     <mirror>
       <name>LeaseWeb (Anycast: Amsterdam)</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.leaseweb.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.leaseweb.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.leaseweb.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.leaseweb.com/gentoo/</uri>
     </mirror>
@@ -310,7 +310,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="PT" countryname="Portugal">
     <mirror>
       <name>RNL - Técnico Lisboa</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.rnl.tecnico.ulisboa.pt/pub/gentoo/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.rnl.tecnico.ulisboa.pt/pub/gentoo/gentoo-distfiles/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.rnl.tecnico.ulisboa.pt/pub/gentoo/gentoo-distfiles/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.rnl.tecnico.ulisboa.pt/pub/gentoo/gentoo-distfiles/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.rnl.tecnico.ulisboa.pt/pub/gentoo/gentoo-distfiles/</uri>
@@ -329,7 +329,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="SE" countryname="Sweden">
     <mirror>
       <name>Linköping University - Lysator</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.lysator.liu.se/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.lysator.liu.se/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.lysator.liu.se/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.lysator.liu.se/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.lysator.liu.se/gentoo/</uri>
@@ -338,7 +338,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="SK" countryname="Slovakia">
     <mirror>
       <name>Wheel.sk</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.wheel.sk/gentoo</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.wheel.sk/gentoo</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.wheel.sk/gentoo</uri>
     </mirror>
     <mirror>
@@ -352,7 +352,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="TR" countryname="Turkey">
     <mirror>
       <name>Turkish Linux Users Group - Linux Kullanicilari Dernegi(LKD)</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp.linux.org.tr/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://ftp.linux.org.tr/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp.linux.org.tr/gentoo-distfiles/</uri>
     </mirror>
   </mirrorgroup>
@@ -363,25 +363,25 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="UK" countryname="UK">
     <mirror>
       <name>Bytemark Hosting</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.bytemark.co.uk/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.bytemark.co.uk/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.bytemark.co.uk/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.bytemark.co.uk/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Get Hosted online</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirrors.gethosted.online/gentoo</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirrors.gethosted.online/gentoo</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirrors.gethosted.online/gentoo</uri>
     </mirror>
     <mirror>
       <name>The UK Mirror Service</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://www.mirrorservice.org/sites/distfiles.gentoo.org/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://www.mirrorservice.org/sites/distfiles.gentoo.org/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://www.mirrorservice.org/sites/distfiles.gentoo.org/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.mirrorservice.org/sites/distfiles.gentoo.org/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://rsync.mirrorservice.org/distfiles.gentoo.org/</uri>
     </mirror>
     <mirror>
       <name>Rackspace Technology</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirror.rackspace.com/gentoo/</uri>
     </mirror>
@@ -389,7 +389,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Australia and Oceania" country="AU" countryname="Australia">
     <mirror>
       <name>AARnet</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.aarnet.edu.au/pub/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.aarnet.edu.au/pub/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.aarnet.edu.au/pub/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.aarnet.edu.au/pub/gentoo/</uri>
     </mirror>
@@ -400,7 +400,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Rackspace Technology</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirror.rackspace.com/gentoo/</uri>
@@ -409,7 +409,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Australia and Oceania" country="NC" countryname="New Caledonia">
     <mirror>
       <name>Lagoon</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.lagoon.nc/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.lagoon.nc/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.lagoon.nc/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirror.lagoon.nc/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.lagoon.nc/gentoo/</uri>
@@ -418,17 +418,17 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Asia" country="CN" countryname="China">
     <mirror>
       <name>Alibaba Cloud Computing</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirrors.aliyun.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirrors.aliyun.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirrors.aliyun.com/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Netease.com, Inc.</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirrors.163.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirrors.163.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirrors.163.com/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Tsinghua University</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.tuna.tsinghua.edu.cn/gentoo</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirrors.tuna.tsinghua.edu.cn/gentoo</uri>
     </mirror>
   </mirrorgroup>
   <mirrorgroup region="Asia" country="HK" countryname="Hong Kong">
@@ -438,7 +438,7 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Rackspace Technology</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://mirror.rackspace.com/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirror.rackspace.com/gentoo/</uri>
@@ -453,14 +453,14 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>JAIST</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.jaist.ac.jp/pub/Linux/Gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.jaist.ac.jp/pub/Linux/Gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp.jaist.ac.jp/pub/Linux/Gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp.jaist.ac.jp/pub/Linux/Gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp.jaist.ac.jp/pub/Linux/Gentoo/</uri>
     </mirror>
     <mirror>
       <name>RIKEN</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp.riken.jp/Linux/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://ftp.riken.jp/Linux/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp.riken.jp/Linux/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp.riken.jp/gentoo/</uri>
     </mirror>
@@ -476,25 +476,25 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     <mirror>
       <name>KAIST</name>
       <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp.kaist.ac.kr/pub/gentoo/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp.kaist.ac.kr/pub/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="n" partial="n">https://ftp.kaist.ac.kr/pub/gentoo/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://ftp.kaist.ac.kr/gentoo/</uri>
       <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp.kaist.ac.kr/gentoo/</uri>
     </mirror>
     <mirror>
       <name>lanet.kr</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp.lanet.kr/pub/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://ftp.lanet.kr/pub/gentoo/</uri>
     </mirror>
   </mirrorgroup>
   <mirrorgroup region="Asia" country="RU" countryname="Russia">
     <mirror>
       <name>Yandex.ru</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.yandex.ru/gentoo-distfiles/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.yandex.ru/gentoo-distfiles/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.yandex.ru/gentoo-distfiles/</uri>
       <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirror.yandex.ru/gentoo-distfiles/</uri>
     </mirror>
     <mirror>
       <name>Alexxy.name</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://gentoo-mirror.alexxy.name/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://gentoo-mirror.alexxy.name/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://gentoo-mirror.alexxy.name/</uri>
     </mirror>
     <mirror>
@@ -518,13 +518,13 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Middle East" country="IL" countryname="Israel">
     <mirror>
       <name>Hamakor FOSS Society</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.isoc.org.il/pub/gentoo/</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.isoc.org.il/pub/gentoo/</uri>
     </mirror>
   </mirrorgroup>
   <mirrorgroup region="Middle East" country="KZ" countryname="Kazakhstan">
     <mirror>
       <name>Neo Lab's</name>
-      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.ps.kz/gentoo/pub</uri>
+      <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.ps.kz/gentoo/pub</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.ps.kz/gentoo/pub</uri>
       <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.ps.kz/gentoo</uri>
     </mirror>


### PR DESCRIPTION
Commit for https filtering support with mirrorselect.  Should be committed atomically with the patch from https://bugs.gentoo.org/730994.