### PR TITLE
repositories: Add elopez-r-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1430,6 +1430,18 @@
     <source type="git">git://github.com/pimvullers/elementary.git</source>
     <feed>https://github.com/pimvullers/elementary/commits/master.atom</feed>
   </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>elopez-r-overlay</name>
+    <description>My Gentoo overlay for Ebuilds</description>
+    <homepage>https://gitlab.com/libre_hackerman/elopez-r-overlay</homepage>
+    <owner type="person">
+      <email>gnu_stallman@protonmail.ch</email>
+      <name>Esteban López Rodríguez</name>
+    </owner>
+    <source type="git">https://gitlab.com/libre_hackerman/elopez-r-overlay.git</source>
+    <source type="git">git+ssh://git@gitlab.com:libre_hackerman/elopez-r-overlay.git</source>
+    <feed>https://gitlab.com/libre_hackerman/elopez-r-overlay/-/commits/master.atom</feed>
+  </repo>
   <repo quality="experimental" status="official">
     <name>emacs</name>
     <description>Provide Emacs and XEmacs related ebuilds which are


### PR DESCRIPTION
https://gitlab.com/libre_hackerman/elopez-r-overlay

### My programs

- **snake-curses**: Snake game written in C with Ncurses. [Homepage](https://gitlab.com/libre_hackerman/snake_curses)
- **enlapsed_time**: Counter of time between events, ideal for the shell prompt. [Homepage](https://gitlab.com/libre_hackerman/enlapsed_time)
- **cwpp**: Wallpaper changer written in C that relies in Feh. [Homepage](https://gitlab.com/libre_hackerman/cwpp)
- **spike-telegram**: Telegram client in Ncurses, written in Python. [Homepage](https://gitlab.com/libre_hackerman/spike)

### General packages

- **ski**: A simple text-mode skiing game. [Homepage](http://www.catb.org/~esr/ski/)
- **tuir**: Browse Reddit from your terminal. [Homepage](https://gitlab.com/ajak/tuir/)
- **progress**: Coreutils Viewer: show progress for cp, rm, dd, and so forth. [Homepage](https://github.com/Xfennec/progress)
- **fprintd**: D-Bus service to access fingerprint readers. [Homepage](https://gitlab.freedesktop.org/libfprint/fprintd)
- **devour**: Window Manager agnostic swallowing feature for terminal emulators. [Homepage](https://github.com/salman-abedin/devour)

### Dependencies

- **kitchen** *(tuir)*: Useful snippets of python code. [Homepage](https://github.com/fedora-infra/kitchen)
- **python-telegram** *(spike-telegram)*: Python client for the Telegram's tdlib. [Homepage](https://github.com/alexander-akhmetov/)
- **pam_wrapper** *(fprintd)*: A tool to test PAM applications and PAM modules. [Homepage](https://cwrap.org/pam_wrapper.html)
