### PR TITLE
mirrors: IPv6 update

### DIFF
--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -475,8 +475,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Middle East" country="IL" countryname="Israel">
     <mirror>
       <name>Hamakor FOSS Society</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.isoc.org.il/pub/gentoo/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.isoc.org.il/pub/gentoo/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.isoc.org.il/pub/gentoo/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.isoc.org.il/pub/gentoo/</uri>
     </mirror>
   </mirrorgroup>
   <mirrorgroup region="Middle East" country="KZ" countryname="Kazakhstan">

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -180,9 +180,10 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>University of Applied Sciences, Esslingen</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
-      <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp-stud.hs-esslingen.de/gentoo/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://ftp-stud.hs-esslingen.de/pub/Mirrors/gentoo/</uri>
+      <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://ftp-stud.hs-esslingen.de/gentoo/</uri>
     </mirror>
     <mirror>
       <name>1&amp;1 Internet SE</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -162,6 +162,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
       <name>Ruhr-Universität Bochum</name>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://linux.rz.ruhr-uni-bochum.de/gentoo-mirror/</uri>
+      <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://linux.rz.ruhr-uni-bochum.de/gentoo</uri>
     </mirror>
     <mirror>
       <name>Uni Erlangen-Nürnberg</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -104,8 +104,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Web4U Mirror</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://gentoo.mirror.web4u.cz/</uri>
-      <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://gentoo.mirror.web4u.cz/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://gentoo.mirror.web4u.cz/</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://gentoo.mirror.web4u.cz/</uri>
     </mirror>
     <mirror>
       <name>UPC Česká republika, a.s.</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -160,8 +160,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Ruhr-Universität Bochum</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://linux.rz.ruhr-uni-bochum.de/download/gentoo-mirror/</uri>
     </mirror>
     <mirror>
       <name>Uni Erlangen-Nürnberg</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -51,8 +51,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
       <name>Rochester Institute of Technology</name>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirrors.rit.edu/gentoo/</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirrors.rit.edu/gentoo/</uri>
-      <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://mirrors.rit.edu/gentoo/</uri>
-      <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirrors.rit.edu/gentoo/</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirrors.rit.edu/gentoo/</uri>
+      <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirrors.rit.edu/gentoo/</uri>
     </mirror>
     <mirror>
       <name>Pair Networks</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -305,8 +305,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Europe" country="SK" countryname="Slovakia">
     <mirror>
       <name>Wheel.sk</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.wheel.sk/gentoo</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.wheel.sk/gentoo</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.wheel.sk/gentoo</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.wheel.sk/gentoo</uri>
     </mirror>
     <mirror>
       <name>Rainside.sk</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -174,7 +174,9 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>Dresden University of Technology/AG DSN</name>
+      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://ftp.wh2.tu-dresden.de/pub/mirrors/gentoo</uri>
       <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://ftp.wh2.tu-dresden.de/pub/mirrors/gentoo</uri>
+      <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://ftp.wh2.tu-dresden.de/gentoo</uri>
     </mirror>
     <mirror>
       <name>University of Applied Sciences, Esslingen</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -482,10 +482,10 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="Middle East" country="KZ" countryname="Kazakhstan">
     <mirror>
       <name>Neo Lab's</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.ps.kz/gentoo/pub</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.ps.kz/gentoo/pub</uri>
-      <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://mirror.ps.kz/gentoo/pub</uri>
-      <uri protocol="rsync" ipv4="y" ipv6="n" partial="n">rsync://mirror.ps.kz/gentoo</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.ps.kz/gentoo/pub</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.ps.kz/gentoo/pub</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirror.ps.kz/gentoo/pub</uri>
+      <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.ps.kz/gentoo</uri>
     </mirror>
   </mirrorgroup>
   <mirrorgroup region="Africa" country="NA" countryname="Namibia">

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -11,9 +11,10 @@ vim: ft=xml et ts=2 sts=2 sw=2:
     </mirror>
     <mirror>
       <name>University of Waterloo</name>
-      <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="y" partial="n">ftp://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.csclub.uwaterloo.ca/gentoo-distfiles/</uri>
+      <uri protocol="rsync" ipv4="y" ipv6="y" partial="n">rsync://mirror.csclub.uwaterloo.ca/gentoo-distfiles</uri>
     </mirror>
     <mirror>
       <name>Gossamer Threads</name>

--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -25,8 +25,8 @@ vim: ft=xml et ts=2 sts=2 sw=2:
   <mirrorgroup region="North America" country="US" countryname="USA">
     <mirror>
       <name>OSU Open Source Lab (Corvallis; New York; Chicago)</name>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">https://gentoo.osuosl.org/</uri>
-      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://gentoo.osuosl.org/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">https://gentoo.osuosl.org/</uri>
+      <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://gentoo.osuosl.org/</uri>
     </mirror>
     <mirror>
       <name>LeaseWeb (Anycast: San Francisco; Dallas; Washington, D.C.; Miami)</name>


### PR DESCRIPTION
Did an audit of all mirror domains for AAAA records and found that some had added rsync URLs.