### PR TITLE
repositories: Add certbot-dns-plugins-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -900,6 +900,18 @@
     <feed>https://github.com/ceamac/overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>certbot-dns-plugins</name>
+    <description lang="en">Overlay for the DNS plugins of the ACME client certbot</description>
+    <homepage>https://github.com/osirisinferi/certbot-dns-plugins-overlay</homepage>
+    <owner type="person">
+      <email>gentoo@flut.demon.nl</email>
+      <name>Osiris Inferi</name>
+    </owner>
+    <source type="git">https://github.com/osirisinferi/certbot-dns-plugins-overlay.git</source>
+    <source type="git">git@github.com:osirisinferi/certbot-dns-plugins-overlay.git</source>
+    <feed>https://github.com/osirisinferi/certbot-dns-plugins-overlay/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>cg</name>
     <description>Computer graphics ebuilds for gentoo</description>
     <homepage>https://github.com/brothermechanic/cg</homepage>


### PR DESCRIPTION
[Certbot](https://certbot.eff.org/) is EFFs ACME client, mainly used to get Let's Encrypt certificates.

Currently, only a single DNS plugin is offered in the main Portage tree, [app-crypt/certbot-dns-nsone](https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone). However, [all other 13 DNS plugins](https://certbot.eff.org/docs/using.html#dns-plugins) are missing from the tree.

The [current recommended DNS plugin installation method for certbot](https://certbot.eff.org/lets-encrypt/gentoo-other#wildcard) is using a Docker image. This is quite overkill, however, no ebuilds for the DNS plugins are available.

This overlay changes that. It contains all 13 DNS plugins currently lacking from the official Gentoo Portage tree. It also contains a few necessary ebuilds for dependencies.

Once this overlay has been added (hopefully), I'll request the certbot team to consider using this overlay in their documentation next to or perhaps even in stead of their current Docker method.