### PR TITLE
used_free_uidgids.sh:  syntax fixup reported by juippis.

### DIFF
--- a/bin/used_free_uidgids.sh
+++ b/bin/used_free_uidgids.sh
@@ -92,7 +92,7 @@ consume()
 
 			if [[ ${range_end} -lt ${ranges[k]} ]]; then
 				ranges[range_end+1]=${ranges[k]}
-				reasons{range_end+1]=${reasons[k]}
+				reasons[range_end+1]=${reasons[k]}
 			fi
 			[[ ${range_start} -gt ${k} ]] && ranges[k]=$(( range_start - 1 ))
 			break


### PR DESCRIPTION
<juippis> bin/used_free_uidgids.sh: line 95: reasons{range_end+1]=RESERVED: command not found

Signed-off-by: Jaco Kroon <jaco@iewc.co.za>