### PR TITLE
Fixed wrong email address

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1324,7 +1324,7 @@
     <description lang="en">Dwosky's personal overlay</description>
     <homepage>https://github.com/Dwosky/Dwosky-overlay</homepage>
     <owner type="person">
-      <email>dwosky@zoho.com</email>
+      <email>dwosky@pm.me</email>
       <name>Pedro Arizmendi</name>
     </owner>
     <source type="git">https://github.com/Dwosky/Dwosky-overlay.git</source>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/772620