### PR TITLE
repositories: Remove regina-gentoo

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4015,17 +4015,6 @@
     <feed>https://gitlab.com/reagentoo/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>regina-gentoo</name>
-    <description lang="en">Regina packages for Gentoo</description>
-    <homepage>https://github.com/WPettersson/regina-gentoo/</homepage>
-    <owner type="person">
-      <email>william@ewpettersson.se</email>
-      <name>William Pettersson</name>
-    </owner>
-    <source type="git">git://github.com/WPettersson/regina-gentoo.git</source>
-    <feed>https://github.com/WPettersson/regina-gentoo/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>ricerlay</name>
     <description lang="en">Overlay for ricing enthusiasts</description>
     <homepage>https://github.com/azahi/ricerlay</homepage>


### PR DESCRIPTION
Dropping a well out-of-date repository that I'd forgotten about