### PR TITLE
uid-gid.txt: allocate GID for dev-erlang/epam

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -365,6 +365,7 @@ cyrus			415	-	acct
 gluster			416	416	acct
 anope			417	417	acct
 usbmux			418	-	acct
+epam			-	418	acct	Used by dev-erlang/epam
 wesnoth			419	419	acct
 davfs2			420	420	acct		Used by net-fs/davfs2
 znc			421	421	acct


### PR DESCRIPTION
Used in https://github.com/gentoo/gentoo/pull/20300

Bug: https://bugs.gentoo.org/766686
Signed-off-by: Florian Schmaus <flo@geekplace.eu>