### PR TITLE
files/overlays/repositories.xml: update src_prepare-overlay owner

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3839,8 +3839,8 @@
     <description lang="en">src_prepare group's Gentoo overlay</description>
     <homepage>https://gitlab.com/src_prepare/src_prepare-overlay.git</homepage>
     <owner type="person">
-      <name>XGQT</name>
-      <email>xgqt@protonmail.com</email>
+      <email>xgqt@riseup.net</email>
+      <name>Maciej Barć</name>
     </owner>
     <source type="git">https://gitlab.com/src_prepare/src_prepare-overlay.git</source>
     <source type="git">git+ssh://git@gitlab.com/src_prepare/src_prepare-overlay.git</source>


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@riseup.net>


for: https://bugs.gentoo.org/793626#c1