### PR TITLE
repositories: Add Spring RTS Gentoo as 'spring'

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4111,6 +4111,18 @@
     <feed>https://github.com/hartwork/gentoo-overlay-sping/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>spring>/name>
+    <description lang="en">Spring RTS Gentoo overlay</description>
+    <homepage>https://github.com/springlobby/overlay</homepage>
+    <owner type="person">
+      <email>spring@abma.de</email>
+      <name>abma</name>
+    </owner>
+    <source type="git">https://github.com/springlobby/overlay.git</source>
+    <source type="git">git+ssh://git@github.com/springlobby/overlay.git</source>
+    <feed>https://github.com/springlobby/overlay/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>squeezebox</name>
     <description lang="en">Packages for the Squeezebox network audio player from Logitech</description>
     <homepage>https://cgit.gentoo.org/user/squeezebox.git/</homepage>


### PR DESCRIPTION
Hello the Gentoo team,

This PR aims to add the 'spring' repository / overlay that is maintained by the Spring RTS game community, in order to facilitate the maintenance of the related `ebuild` for engine and lobbies. On behalf of @abma, current community leader, that acknowledged this request in https://github.com/springlobby/overlay/issues/25.

