### PR TITLE
repositories: add third-party-certbot-dns-plugins overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4463,6 +4463,18 @@
     <feed>https://gitlab.com/TheGreatMcPain/thegreatmcpain-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>third-party-certbot-dns-plugins</name>
+    <description lang="en">Overlay for unofficial, third party DNS plugins of the ACME client certbot</description>
+    <homepage>https://github.com/osirisinferi/third-party-certbot-dns-plugins</homepage>
+    <owner type="person">
+      <email>gentoo@flut.nl.eu.org</email>
+      <name>Osiris Inferi</name>
+    </owner>
+    <source type="git">https://github.com/osirisinferi/third-party-certbot-dns-plugins.git</source>
+    <source type="git">git@github.com:osirisinferi/third-party-certbot-dns-plugins.git</source>
+    <feed>https://github.com/osirisinferi/third-party-certbot-dns-plugins/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>tmacedo</name>
     <description>User Overlay</description>
     <homepage>https://github.com/tmacedo/portage</homepage>


### PR DESCRIPTION
Some time ago I already started the [certbot-dns-plugins-overlay](https://github.com/osirisinferi/certbot-dns-plugins-overlay) containing all the *official* DNS plugins in the Certbot repository. However, there are also many third party DNS plugins on the web available, especially since the Certbot team decided not to include more DNS plugins in their own repository.

Therefore, I've also started a overlay for third party DNS plugins for Certbot which, I think, could benefit Gentoo users around the world.