### PR TITLE
repositories: Add dinolay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1026,6 +1026,19 @@
     <!-- <feed>https://cgit.gentoo.org/dev/dilfridge.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>dinolay</name>
+    <description lang="en">My gentoo overlay for me to not need to use multiple ones</description>
+    <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
+    <owner type="person">
+      <email>truncateddinosour@gmail.com</email>
+      <name>Ari Archer</name>
+    </owner>
+    <source type="git">https://github.com/TruncatedDinosour/dinolay.git</source>
+    <source type="git">git://github.com/TruncatedDinosour/dinolay.git</source>
+    <source type="git">git@github.com:TruncatedDinosour/dinolay.git</source>
+    <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>displacer</name>
     <description lang="en">Fixes and new unstable packages</description>
     <homepage>https://cgit.gentoo.org/user/displacer.git/</homepage>
@@ -1096,19 +1109,6 @@
     <source type="git">git://github.com/dmchurch/portage-overlay.git</source>
     <source type="git">git@github.com:dmchurch/portage-overlay.git</source>
     <feed>https://github.com/dmchurch/portage-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>dinolay</name>
-    <description lang="en">My gentoo overlay for me to not need to use multiple ones</description>
-    <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
-    <owner type="person">
-      <email>truncateddinosour@gmail.com</email>
-      <name>Ari Archer</name>
-    </owner>
-    <source type="git">https://github.com/TruncatedDinosour/dinolay.git</source>
-    <source type="git">git://github.com/TruncatedDinosour/dinolay.git</source>
-    <source type="git">git@github.com:TruncatedDinosour/dinolay.git</source>
-    <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="official">
     <name>dotnet</name>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5151,5 +5151,18 @@
     <source type="git">git@github.com:kabili207/zyrenth-overlay.git</source>
     <feed>https://github.com/kabili207/zyrenth-overlay/commits/master.atom</feed>
   </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>dinolay</name>
+    <description lang="en">My gentoo overlay for me to not need to use multiple ones</description>
+    <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
+    <owner type="person">
+      <email>truncateddinosour@gmail.com</email>
+      <name>Ari Archer</name>
+    </owner>
+    <source type="git">https://github.com/TruncatedDinosour/dinolay.git</source>
+    <source type="git">git://github.com/TruncatedDinosour/dinolay.git</source>
+    <source type="git">git@github.com:TruncatedDinosour/dinolay.git</source>
+    <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
+  </repo>
   <!-- vim:se et sw=2 ts=2 sts=2 :-->
 </repositories>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1027,7 +1027,7 @@
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>dinolay</name>
-    <description lang="en">My gentoo overlay for me to not need to use multiple ones</description>
+    <description lang="en">TruncatedDinosour's overlay</description>
     <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
     <owner type="person">
       <email>truncateddinosour@gmail.com</email>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1097,6 +1097,19 @@
     <source type="git">git@github.com:dmchurch/portage-overlay.git</source>
     <feed>https://github.com/dmchurch/portage-overlay/commits/master.atom</feed>
   </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>dinolay</name>
+    <description lang="en">My gentoo overlay for me to not need to use multiple ones</description>
+    <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
+    <owner type="person">
+      <email>truncateddinosour@gmail.com</email>
+      <name>Ari Archer</name>
+    </owner>
+    <source type="git">https://github.com/TruncatedDinosour/dinolay.git</source>
+    <source type="git">git://github.com/TruncatedDinosour/dinolay.git</source>
+    <source type="git">git@github.com:TruncatedDinosour/dinolay.git</source>
+    <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
+  </repo>
   <repo quality="experimental" status="official">
     <name>dotnet</name>
     <description>Experimental overlay for .NET packages.</description>
@@ -5150,19 +5163,6 @@
     <source type="git">git://github.com/kabili207/zyrenth-overlay.git</source>
     <source type="git">git@github.com:kabili207/zyrenth-overlay.git</source>
     <feed>https://github.com/kabili207/zyrenth-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>dinolay</name>
-    <description lang="en">My gentoo overlay for me to not need to use multiple ones</description>
-    <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
-    <owner type="person">
-      <email>truncateddinosour@gmail.com</email>
-      <name>Ari Archer</name>
-    </owner>
-    <source type="git">https://github.com/TruncatedDinosour/dinolay.git</source>
-    <source type="git">git://github.com/TruncatedDinosour/dinolay.git</source>
-    <source type="git">git@github.com:TruncatedDinosour/dinolay.git</source>
-    <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
   </repo>
   <!-- vim:se et sw=2 ts=2 sts=2 :-->
 </repositories>


### PR DESCRIPTION
[This](https://github.com/TruncatedDinosour/dinolay) overlay consists of:
- Packages I use, but they're not in the gentoo main repo
- Utilities I made and made them into an ebuild
- Custom ebuilds
- Git packages
- Packages that are in the gentoo repos, but they don't meet my satisfaction (like transmission, but I want transmission-cli)