### PR TITLE
update gentoo-zh overlay urls

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1753,7 +1753,9 @@
     <owner type="person">
       <email>microcai@fedoraproject.org</email>
     </owner>
+    <source type="git">https://github.com/microcai/gentoo-zh.git</source>
     <source type="git">git://github.com/microcai/gentoo-zh.git</source>
+    <source type="git">git+ssh://github.com/microcai/gentoo-zh.git</source>
     <feed>https://github.com/microcai/gentoo-zh/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">


### PR DESCRIPTION
provide multiple protocol urls for gentoo-zh overlay rather than a single git:// protocol. git:// protocol will be abondend soon after.