### PR TITLE
Remove `-dns` from existing repository

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4504,16 +4504,16 @@
     <feed>https://gitlab.com/TheGreatMcPain/thegreatmcpain-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>third-party-certbot-dns-plugins</name>
-    <description lang="en">Overlay for unofficial, third party DNS plugins of the ACME client certbot</description>
-    <homepage>https://github.com/osirisinferi/third-party-certbot-dns-plugins</homepage>
+    <name>third-party-certbot-plugins</name>
+    <description lang="en">Overlay for unofficial, third party plugins of the ACME client Certbot</description>
+    <homepage>https://github.com/osirisinferi/third-party-certbot-plugins</homepage>
     <owner type="person">
       <email>gentoo@flut.nl.eu.org</email>
       <name>Osiris Inferi</name>
     </owner>
-    <source type="git">https://github.com/osirisinferi/third-party-certbot-dns-plugins.git</source>
-    <source type="git">git@github.com:osirisinferi/third-party-certbot-dns-plugins.git</source>
-    <feed>https://github.com/osirisinferi/third-party-certbot-dns-plugins/commits/main.atom</feed>
+    <source type="git">https://github.com/osirisinferi/third-party-certbot-plugins.git</source>
+    <source type="git">git@github.com:osirisinferi/third-party-certbot-plugins.git</source>
+    <feed>https://github.com/osirisinferi/third-party-certbot-plugins/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>tmacedo</name>


### PR DESCRIPTION
I've chosen to remove the "DNS" part from the overlay, as there are many other non-DNS third party plugins available.

Due to the magic of GitHubs repository renaming, the old repository is automatically still available, redirecting to the new one and will use the actual content of the renamed repository, so this would not be a breaking change for users already using the older repository if they didn't update through `eselect` or `layman`, but just keep syncing the existing repo.