### PR TITLE
Update source url of cj-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -845,7 +845,7 @@
     <owner type="person">
       <email>junghans@gentoo.org</email>
     </owner>
-    <source type="git">git://github.com/junghans/cj-overlay</source>
+    <source type="git">https://github.com/junghans/cj-overlay</source>
     <feed>https://github.com/junghans/cj-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/835901