### PR TITLE
repositories.xml: remove 'stowe-verlay' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4128,18 +4128,6 @@
     <feed>https://github.com/stha09/gpo-stha09/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>stowe-verlay</name>
-    <description>Few things that have either broken elsewhere or fallen unmaintained, such as winexe, a source-based version of logitech media server, a patched version of dansguardian</description>
-    <homepage>https://github.com/mwstowe/stowe-verlay</homepage>
-    <owner type="person">
-      <email>mstowe@chicago.us.mensa.org</email>
-      <name>Michael Stowe</name>
-    </owner>
-    <source type="git">https://github.com/mwstowe/stowe-verlay.git</source>
-    <source type="git">git+ssh://git@github.com/mwstowe/stowe-verlay.git</source>
-    <feed>https://github.com/mwstowe/stowe-verlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>strohel</name>
     <description lang="en">strohel's overlay</description>
     <homepage>https://github.com/strohel/strohel-overlay</homepage>


### PR DESCRIPTION
Longstanding CI failures, overlay appears to be updated, but failures
haven't been addressed.

Closes: https://bugs.gentoo.org/767652
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>