### PR TITLE
repositories.xml: remove 'squeezebox' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4041,20 +4041,6 @@
     <feed>https://github.com/spring/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>squeezebox</name>
-    <description lang="en">Packages for the Squeezebox network audio player from Logitech</description>
-    <homepage>https://cgit.gentoo.org/user/squeezebox.git/</homepage>
-    <owner type="person">
-      <email>stuart@hickinbottom.com</email>
-      <name>Stuart Hickinbottom</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/user/squeezebox.git</source>
-    <source type="git">git://anongit.gentoo.org/user/squeezebox.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/user/squeezebox.git</source>
-    <feed>https://cgit.gentoo.org/user/squeezebox.git/atom/</feed>
-    <!-- <feed>https://cgit.gentoo.org/user/squeezebox.git/rss/</feed> -->
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>src_prepare-overlay</name>
     <description lang="en">src_prepare group's Gentoo overlay</description>
     <homepage>https://gitlab.com/src_prepare/src_prepare-overlay.git</homepage>


### PR DESCRIPTION
Long-standing CI failures. Repository hasn't been updated in over a
year.

Closes: https://bugs.gentoo.org/797157
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>