### PR TITLE
repositories.xml: remove 'bitcetera' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -604,18 +604,6 @@
     <!-- <feed>https://cgit.gentoo.org/dev/bircoph.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>bitcetera</name>
-    <description lang="en">Miscellaneous Gentoo ebuilds</description>
-    <homepage>https://github.com/svoop/bitcetera-overlay</homepage>
-    <owner type="person">
-      <email>gentoo@bitcetera.com</email>
-      <name>Sven Schwyn</name>
-    </owner>
-    <source type="git">https://github.com/svoop/bitcetera-overlay.git</source>
-    <source type="git">git@github.com:svoop/bitcetera-overlay.git</source>
-    <feed>https://github.com/svoop/bitcetera-overlay/commits/main.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>bitcoin</name>
     <description>Bitcoin and CPU/GPU mining related ebuilds</description>
     <homepage>https://gitlab.com/bitcoin/gentoo.git</homepage>


### PR DESCRIPTION
Long-standing CI failures related to EAPI=2 usage and unknown eclasses that
haven't been addressed.

Closes: https://bugs.gentoo.org/789180
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>