### PR TITLE
repositories.xml: remove 'octopus' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2961,18 +2961,6 @@
     <feed>https://github.com/neeshy/nymphos/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>octopus</name>
-    <description lang="en">Own and claimed ebuilds</description>
-    <homepage>https://github.com/Bfgeshka/octopus</homepage>
-    <owner type="person">
-      <email>bfg@derpy.ru</email>
-      <name>Bfgeshka</name>
-    </owner>
-    <source type="git">https://github.com/Bfgeshka/octopus.git</source>
-    <source type="git">git+ssh://git@github.com/Bfgeshka/octopus.git</source>
-    <feed>https://github.com/Bfgeshka/octopus/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>oddlama</name>
     <description lang="en">oddlama's gentoo overlay</description>
     <homepage>https://github.com/oddlama/overlay</homepage>


### PR DESCRIPTION
Long-standing CI failures. Repository hasn't been updated in over a year.

Closes: https://bugs.gentoo.org/782307
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>