### PR TITLE
repositories: Add xutaxkamay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3005,6 +3005,18 @@
     <feed>https://github.com/chriscpritchard/overseerr-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>oxen-overlay</name>
+    <description lang="en">Personal overlay for OXEN projects</description>
+    <homepage>https://github.com/xutaxkamay/gentoo-oxen</homepage>
+    <owner type="person">
+      <email>admin@xutaxkamay.com</email>
+      <name>Xutax Kamay</name>
+    </owner>
+    <source type="git">https://github.com/xutaxkamay/gentoo-oxen.git</source>
+    <source type="git">git@github.com:xutaxkamay/gentoo-oxen.git</source>
+    <feed>https://github.com/xutaxkamay/gentoo-oxen/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>palemoon</name>
     <description lang="en">Unofficial Gentoo overlay for the Pale Moon (http://www.palemoon.org/) web browser.</description>
     <homepage>https://github.com/deu/palemoon-overlay</homepage>


### PR DESCRIPTION
This is my personal overlay for adding OXEN projects into Gentoo's unofficial arsenal (https://oxen.io).
Contains LokiNET and OXEN (wallet-cli, daemon) packages with OpenRC scripts.