### PR TITLE
uid-gid.txt: add uid/gid for net-vpn/headscale

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -604,6 +604,7 @@ gitlab-runner			510		510		acct
 rrdcached			511		511		acct
 soffice				512		512		requested
 openttd				513		513		acct
+headscale			514		514		acct		Used by net-vpn/headscale daemon user
 -				750..999	750..999	reserved	Dynamic allocation by user.eclass. Do not use!
 -				1000..60000	1000..60000	reserved	`UID_MIN`..`UID_MAX` / `GID_MIN`..`GID_MAX` in login.defs
 ventrilo			3784		3784		historical	Used by media-sound/ventrilo-server-bin, removed in [15c6a556cef2](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=15c6a556cef202a72f7226648ebea19fcffe834d)


### PR DESCRIPTION
I am trying to add a new package net-vpn/headscale to the official repository.
In order to run headscale more securely, I created corresponding users and groups.

For this, I want to apply the uid and gid of the headscale( uid/gid 514)

The uid and gid in the pr I submitted are 600, but don't worry, after the current pr is merged, I will modify the uid and gid information in the submitted commit.

Github PR: https://github.com/gentoo/gentoo/pull/25212

Bug: https://bugs.gentoo.org/841017
Signed-off-by: Chris Su <chris@lesscrowds.org>