### PR TITLE
uid-gid.txt: add uid/gid for net-im/synapse

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -610,6 +610,7 @@ sonarr				515		515		acct
 radarr				516		516		acct
 prowlarr			517		517		acct
 jellyfin			518		518		acct
+synapse				519		519		acct		Used by net-im/synapse Matrix server
 -				750..999	750..999	reserved	Dynamic allocation by user.eclass. Do not use!
 -				1000..60000	1000..60000	reserved	`UID_MIN`..`UID_MAX` / `GID_MIN`..`GID_MAX` in login.defs
 ventrilo			3784		3784		historical	Used by media-sound/ventrilo-server-bin, removed in [15c6a556cef2](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=15c6a556cef202a72f7226648ebea19fcffe834d)


### PR DESCRIPTION
This is a request for adding UID/GID 519 for `net-im/synapse` which I am trying to push to `::gentoo` in https://github.com/gentoo/gentoo/pull/25776.