### PR TITLE
Reinstate poly-c overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3157,6 +3157,16 @@
     <source type="git">git+ssh://git@github.com/comio/plex-overlay.git</source>
     <feed>https://github.com/comio/plex-overlay/commits/master.atom</feed>
   </repo>
+  <repo quality="experimental" status="official">
+    <name>poly-c</name>
+    <description lang="en">Polynomial-C's overlay</description>
+    <homepage>http://www.gentoofan.org/gentoo/</homepage>
+    <owner type="person">
+      <email>polynomial-c@gentoo.org</email>
+      <name>Lars Wendler</name>
+    </owner>
+    <source type="rsync">rsync://rsync.gentoofan.org/poly-c</source>
+  </repo>
   <repo quality="experimental" status="unofficial">
     <name>powerman</name>
     <description>Overlay of Alex Efros</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3157,12 +3157,12 @@
     <source type="git">git+ssh://git@github.com/comio/plex-overlay.git</source>
     <feed>https://github.com/comio/plex-overlay/commits/master.atom</feed>
   </repo>
-  <repo quality="experimental" status="official">
+  <repo quality="experimental" status="unofficial">
     <name>poly-c</name>
     <description lang="en">Polynomial-C's overlay</description>
     <homepage>http://www.gentoofan.org/gentoo/</homepage>
     <owner type="person">
-      <email>polynomial-c@gentoo.org</email>
+      <email>polynomial-c@gmx.de</email>
       <name>Lars Wendler</name>
     </owner>
     <source type="rsync">rsync://rsync.gentoofan.org/poly-c</source>


### PR DESCRIPTION
Not sure why this was removed. I never said I will stop using Gentoo. In fact still I regularly update my overlay.