### PR TITLE
repositories.xml: Fix XML formatting + remove 'panther' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3000,18 +3000,6 @@
     <feed>https://github.com/deu/palemoon-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>panther</name>
-    <description lang="en">Fun useful packages not found elsewhere</description>
-    <homepage>https://github.com/orangeturtle739/panther</homepage>
-    <owner type="person">
-      <email>swimgiraffe435@gmail.com</email>
-      <name>Jacob Glueck</name>
-    </owner>
-    <source type="git">https://github.com/orangeturtle739/panther.git</source>
-    <source type="git">git+ssh://git@github.com/orangeturtle739/panther.git</source>
-    <feed>https://github.com/orangeturtle739/panther/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>pdilung</name>
     <description lang="en">Personal Gentoo overlay of Pavol Dilung</description>
     <homepage>https://github.com/pdilung/gentoo-overlay/</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1344,8 +1344,8 @@
     <description lang="en">Graphics, C++ libs and additional software</description>
     <homepage>https://github.com/feniksa/gentoo-overlay</homepage>
     <owner type="person">
-     <email>feniksa@200volts.com</email>
-     <name>Maksym Sditanov</name>
+      <email>feniksa@200volts.com</email>
+      <name>Maksym Sditanov</name>
     </owner>
     <source type="git">https://github.com/feniksa/gentoo-overlay.git</source>
     <source type="git">git+ssh://git@github.com/feniksa/gentoo-overlay.git</source>


### PR DESCRIPTION
Small fix in indentation found with xmlstarlet.

---

The author asked to have the overlay removed as they can no longer
maintain it.

Closes: https://bugs.gentoo.org/859049