### PR TITLE
Seeking to reserve UID/GID 525

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -617,6 +617,7 @@ readarr				521		521		acct
 gns3				522		522		acct
 goaccess			523		523		acct
 owntracks			524		524		acct		Used by sci-geosciences/owntracks-recorder
+ledgersmb			525		525	        acct            Used by app-office/ledgersmb
 
 -				750..999	750..999	reserved	Dynamic allocation by user.eclass. Do not use!
 -				1000..60000	1000..60000	reserved	`UID_MIN`..`UID_MAX` / `GID_MIN`..`GID_MAX` in login.defs


### PR DESCRIPTION
I am packaging LedgerSMB (a small to midsized accounting application) and hope to move it out of an overlay and into Gentoo's main repository over time.  I need a UID/GID for the server process to run under and so would like to reserve 525 for this.