### PR TITLE
Re-add Rust overlay using current URLs

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3492,6 +3492,17 @@
     <feed>https://github.com/Atoms/rukruk/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>rust</name>
+    <description lang="en">rust modules and tools</description>
+    <homepage>https://cgit.gentoo.org/repo/proj/rust.git/</homepage>
+    <owner type="project">
+      <email>rust@gentoo.org</email>
+      <name>Rust Team</name>
+    </owner>
+    <source type="git">https://anongit.gentoo.org/git/repo/proj/rust.git</source>
+    <source type="git">git+ssh://git@git.gentoo.org/repo/proj/rust.git</source>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>ryans</name>
     <description lang="en">Personal ebuild repository.</description>
     <homepage>https://github.com/bekcpear/ryans-repos</homepage>


### PR DESCRIPTION
Removal of the Rust overlay is something that should never have happened to begin with. It's still maintained, but it sure as hell isn't listed.