### PR TITLE
repositories.xml: remove 'reagentoo' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -635,18 +635,6 @@
     <feed>https://gitweb.gentoo.org/repo/proj/blender-gentoo-logo.git/atom/?h=master</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>bloody</name>
-    <description lang="en">krita bleeding edge and artists tools/resources</description>
-    <homepage>https://github.com/bloodywing/bloody</homepage>
-    <owner type="person">
-      <email>bloodywing@neocomy.net</email>
-      <name>Pierre Geier</name>
-    </owner>
-    <source type="git">https://github.com/bloodywing/bloody.git</source>
-    <source type="git">git@github.com:bloodywing/bloody.git</source>
-    <feed>https://github.com/bloodywing/bloody/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>bobwya</name>
     <description lang="en">Miscellaneous Gentoo ebuilds</description>
     <homepage>https://github.com/bobwya/miscellaneous_ebuilds</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3277,17 +3277,6 @@
     <feed>https://github.com/mahatma-kaganovich/raw/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>reagentoo</name>
-    <description lang="en">reagentoo's overlay</description>
-    <homepage>https://gitlab.com/reagentoo/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>reagentoo@gmail.com</email>
-    </owner>
-    <source type="git">https://gitlab.com/reagentoo/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@gitlab.com/reagentoo/gentoo-overlay.git</source>
-    <feed>https://gitlab.com/reagentoo/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>ricerlay</name>
     <description lang="en">Overlay for ricing enthusiasts</description>
     <homepage>https://github.com/azahi/ricerlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4425,18 +4425,18 @@
     <source type="git">git@github.com:vifino/vifino-overlay.git</source>
     <feed>https://github.com/vifino/vifino-overlay/commits/master.atom</feed>
   </repo>
-    <repo quality="experimental" status="unofficial">
-      <name>violet-funk</name>
-      <description lang="en">Personal Gentoo overlay for FNF and FNF mod ebuilds.</description>
-      <homepage>https://github.com/MagelessMayhem/violet-funk</homepage>
-      <owner type="person">
-        <email>MagelessMayhem@protonmail.com</email>
-        <name>Sebastian France</name>
-      </owner>
-      <source type="git">https://github.com/MagelessMayhem/violet-funk.git</source>
-      <source type="git">git+ssh://git@github.com/MagelessMayhem/violet-funk.git</source>
-      <feed>https://github.com/MagelessMayhem/violet-funk/commits/master.atom</feed>
-    </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>violet-funk</name>
+    <description lang="en">Personal Gentoo overlay for FNF and FNF mod ebuilds.</description>
+    <homepage>https://github.com/MagelessMayhem/violet-funk</homepage>
+    <owner type="person">
+      <email>MagelessMayhem@protonmail.com</email>
+      <name>Sebastian France</name>
+    </owner>
+    <source type="git">https://github.com/MagelessMayhem/violet-funk.git</source>
+    <source type="git">git+ssh://git@github.com/MagelessMayhem/violet-funk.git</source>
+    <feed>https://github.com/MagelessMayhem/violet-funk/commits/master.atom</feed>
+  </repo>
   <repo quality="experimental" status="unofficial">
     <name>viperML-overlay</name>
     <description lang="en">viperML's personal overlay</description>


### PR DESCRIPTION
Has had errors since August, pings have gone unanswered.

Closes: https://bugs.gentoo.org/864689
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>

---
Also fix XML formatting (in a separate commit).
