### PR TITLE
repositories: drop 2xsaiko overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -59,18 +59,6 @@
   FIN
   -->
   <repo quality="experimental" status="unofficial">
-    <name>2xsaiko</name>
-    <description lang="en">Personal overlay with no special focus</description>
-    <homepage>https://git.sr.ht/~dblsaiko/ebuilds</homepage>
-    <owner type="person">
-      <email>me@dblsaiko.net</email>
-      <name>2xsaiko</name>
-    </owner>
-    <source type="git">https://git.sr.ht/~dblsaiko/ebuilds</source>
-    <source type="git">git@git.sr.ht:~dblsaiko/ebuilds</source>
-    <feed>https://git.sr.ht/~dblsaiko/ebuilds/log/rss.xml</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>4nykey</name>
     <description lang="en">An experimental portage overlay</description>
     <homepage>https://github.com/4nykey/4nykey</homepage>


### PR DESCRIPTION
Removed because I don't currently maintain it.

Closes https://bugs.gentoo.org/show_bug.cgi?id=889468.