### PR TITLE
repositories.xml: remove overlays kske, thamognya

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2267,17 +2267,6 @@
     <feed>https://github.com/kripton/kripton-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>kske</name>
-    <description lang="en">Kai S. K. Engelbart's personal overlay</description>
-    <homepage>https://git.kske.dev/kske/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>kai@kske.dev</email>
-      <name>Kai S. K. Engelbart</name>
-    </owner>
-    <source type="git">https://git.kske.dev/kske/gentoo-overlay.git</source>
-    <source type="git">ssh://git@git.kske.dev:420/kske/gentoo-overlay.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>kzd</name>
     <description lang="en">kzd's personal overlay</description>
     <homepage>https://gitlab.com/kzdixon/kzd-ebuilds</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2244,7 +2244,7 @@
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>kostas-overlay</name>
-	<description lang="en">Personal ebuild repository</description>
+    <description lang="en">Personal ebuild repository</description>
     <homepage>https://github.com/KostasEreksonas/kostas-overlay</homepage>
     <owner type="person">
       <email>k.ereksonas@gmail.com</email>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4221,17 +4221,6 @@
     <feed>https://github.com/tgbugs/tgbugs-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>thamognya</name>
-    <description lang="en">Thamognya's Personal overlay.</description>
-    <homepage>https://git.thamognya.com/Thamognya/thamognya-overlay</homepage>
-    <owner type="person">
-      <email>contact@thamognya.com</email>
-      <name>Thamognya Kodi</name>
-    </owner>
-    <source type="git">https://git.thamognya.com/Thamognya/thamognya-overlay.git</source>
-    <feed>https://github.com/Thamognya/thamognya-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>thegreatmcpain</name>
     <description lang="en">TheGreatMcPain's personal ebuild overlay</description>
     <homepage>https://gitlab.com/TheGreatMcPain/thegreatmcpain-overlay</homepage>


### PR DESCRIPTION
**repositories.xml: remove 'kske' overlay**

Repository has been gone since December 2022.

Closes: https://bugs.gentoo.org/887719
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>

---

**repositories.xml: remove 'thamognya' overlay**

Repository has been gone since December 2022.

Closes: https://bugs.gentoo.org/881235
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>