### PR TITLE
Update owner email for `zerodaysfordays` overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -5444,7 +5444,7 @@
     <description>Jakob L. Kreuze's personal overlay.</description>
     <homepage>https://github.com/tsarfox/zerodaysfordays</homepage>
     <owner type="person">
-      <email>zerodaysfordays@sdf.lonestar.org</email>
+      <email>zerodaysfordays@sdf.org</email>
       <name>Jakob L. Kreuze</name>
     </owner>
     <source type="git">https://github.com/tsarfox/zerodaysfordays</source>


### PR DESCRIPTION
Per Michał Górny's comment in https://bugs.gentoo.org/864715