### PR TITLE
Update owner email for `tatsh-overlay` overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4114,7 +4114,7 @@
     <description lang="en">Overlay from Tatsh - emulators/fonts/game/misc</description>
     <homepage>https://github.com/Tatsh/tatsh-overlay</homepage>
     <owner type="person">
-      <email>audvare+overlay@gmail.com</email>
+      <email>audvare@gmail.com</email>
       <name>Andrew Udvare</name>
     </owner>
     <source type="git">https://github.com/Tatsh/tatsh-overlay.git</source>


### PR DESCRIPTION
Closes https://bugs.gentoo.org/899594