### PR TITLE
Remove failing overlays

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -582,18 +582,6 @@
     <source type="git">git@github.com:blackburn29/blackburn29-overlay.git</source>
     <feed>https://github.com/blackburn29/blackburn29-overlay/commits/master.atom</feed>
   </repo>
-  <repo quality="experimental" status="official">
-    <name>blender-gentoo-logo</name>
-    <description lang="en">Software needed to render the Blender-based gentoo Logo of 2003</description>
-    <homepage>https://gitweb.gentoo.org/repo/proj/blender-gentoo-logo.git/</homepage>
-    <owner type="person">
-      <email>sping@gentoo.org</email>
-      <name>Sebastian Pipping</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/repo/proj/blender-gentoo-logo.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/repo/proj/blender-gentoo-logo.git</source>
-    <feed>https://gitweb.gentoo.org/repo/proj/blender-gentoo-logo.git/atom/?h=master</feed>
-  </repo>
   <repo quality="experimental" status="unofficial">
     <name>bobwya</name>
     <description lang="en">Miscellaneous Gentoo ebuilds</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4643,19 +4643,6 @@
     </owner>
     <source type="rsync">rsync://gentoo.zugaina.org/zugaina-portage</source>
   </repo>
-  <repo quality="experimental" status="official">
-    <name>zx2c4</name>
-    <description lang="en">zx2c4's repository of additional ebuilds</description>
-    <homepage>http://git.zx2c4.com/portage/</homepage>
-    <owner type="person">
-      <email>zx2c4@gentoo.org</email>
-      <name>Jason A. Donenfeld</name>
-    </owner>
-    <source type="git">git://git.zx2c4.com/portage</source>
-    <source type="git">http://git.zx2c4.com/portage</source>
-    <source type="git">ssh://git@git.zx2c4.com/portage</source>
-    <feed>http://git.zx2c4.com/portage/atom/?h=master</feed>
-  </repo>
   <repo quality="experimental" status="unofficial">
     <name>zyrenth</name>
     <description lang="en">Personal overlay</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4015,20 +4015,6 @@
     <source type="rsync">rsync://rsync.gentoo.stealer.net/swegener-overlay/</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>swirl</name>
-    <description lang="en">Overlay for software I use or made</description>
-    <homepage>https://github.com/binex-dsk/ebuilds</homepage>
-    <owner type="person">
-      <email>swurl@swurl.xyz</email>
-      <name>Carson Rueter</name>
-    </owner>
-    <source type="git">https://github.com/binex-dsk/ebuilds.git</source>
-    <source type="git">git@github.com:binex-dsk/ebuilds.git</source>
-    <source type="git">https://git.swurl.xyz/swirl/ebuilds.git</source>
-    <source type="git">gitea@git.swurl.xyz:swirl/ebuilds.git</source>
-    <feed>https://github.com/binex-dsk/ebuilds/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>SwordArMor</name>
     <description lang="en">Personnal overlay of alarig/SwordArMor</description>
     <homepage>https://git.grifon.fr/alarig/SwordArMor-gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1559,17 +1559,6 @@
     <feed>https://github.com/qwe795138426/fyn-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>gamarouns</name>
-    <description>Bits and pieces missing in gentoo or layman repos I need</description>
-    <homepage>https://github.com/Amaroun/gamarouns</homepage>
-    <owner type="person">
-      <email>vit.kasal@gmail.com</email>
-      <name>amaroun</name>
-    </owner>
-    <source type="git">https://github.com/Amaroun/gamarouns.git</source>
-    <source type="git">git+ssh://git@github.com/Amaroun/gamarouns.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>gamerlay</name>
     <description>
       Gamers overlay for all various games. Not related with games team.

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1785,18 +1785,6 @@
     <source type="git">git+ssh://git@github.com/windfail/griffon_overlay.git</source>
     <feed>https://github.com/windfail/griffon_overlay/commits/master.atom</feed>
   </repo>
-  <repo quality="experimental" status="official">
-    <name>grub2-themes</name>
-    <description lang="en">Overlay dedicated to Grub2 themes (of any distribution)</description>
-    <homepage>https://gitweb.gentoo.org/repo/proj/grub2-themes.git/</homepage>
-    <owner type="person">
-      <email>sping@gentoo.org</email>
-      <name>Sebastian Pipping</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/repo/proj/grub2-themes.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/repo/proj/grub2-themes.git</source>
-    <feed>https://gitweb.gentoo.org/repo/proj/grub2-themes.git/atom/?h=master</feed>
-  </repo>
   <repo quality="experimental" status="unofficial">
     <name>gsview-overlay</name>
     <description lang="en">Overlay for the gsview and some other plotting/scientific soft</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1675,17 +1675,6 @@
     <!-- <feed>https://cgit.gentoo.org/proj/gnustep.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>go-overlay</name>
-    <description lang="en">Golang related ebuilds</description>
-    <homepage>https://github.com/Dr-Terrible/go-overlay</homepage>
-    <owner type="person">
-      <email>toffanin.mauro@gmail.com</email>
-      <name>Mauro Toffanin</name>
-    </owner>
-    <source type="git">https://github.com/Dr-Terrible/go-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/Dr-Terrible/go-overlay.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>goduck777</name>
     <description lang="en">Personal overlay containing some not-so-popular apps</description>
     <homepage>https://github.com/goduck777/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -208,20 +208,6 @@
     <feed>https://cgit.gentoo.org/dev/alexxy.git/atom/</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>aluco</name>
-    <description lang="en">From drm-next to phoronix-test-suite ebuilds</description>
-    <homepage>https://cgit.gentoo.org/user/aluco.git/</homepage>
-    <owner type="person">
-      <email>anthoine.bourgeois@gmail.com</email>
-      <name>Anthoine Bourgeois</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/user/aluco.git</source>
-    <source type="git">git://anongit.gentoo.org/user/aluco.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/user/aluco.git</source>
-    <feed>https://cgit.gentoo.org/user/aluco.git/atom/</feed>
-    <!-- <feed>https://cgit.gentoo.org/user/aluco.git/rss/</feed> -->
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>alxu</name>
     <description lang="en">Alex Xu (Hello71) personal overlay</description>
     <homepage>https://cgit.alxu.ca/gentoo-overlay.git/</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2535,17 +2535,6 @@
     <source type="git">git+ssh://git@github.com/miramir/miramir-layman.git</source>
     <feed>https://github.com/miramir/miramir-layman/commits/master.atom</feed>
   </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>moaxcp</name>
-    <description lang="en">gentoo overlay for packages</description>
-    <homepage>https://github.com/moaxcp/moaxcp-gentoo-overlay</homepage>
-    <owner type="person">
-      <email>moaxcp@gmail.com</email>
-      <name>John Mercier</name>
-    </owner>
-    <source type="git">https://github.com/moaxcp/moaxcp-gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/moaxcp/moaxcp-gentoo-overlay.git</source>
-  </repo>
   <repo quality="testing" status="unofficial">
     <name>moexiami</name>
     <description lang="en">Contains updated ebuilds (w/ more feature/control)

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1947,17 +1947,6 @@
     <source type="git">git+ssh://git@github.com/jabuxas/overlay.git</source>
     <feed>https://github.com/jabuxas/overlay/commits/main.atom</feed>
   </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>jacendi-overlay</name>
-    <description lang="en">id Software games overlay</description>
-    <homepage>https://bitbucket.org/jacendi/jacendi-overlay</homepage>
-    <owner type="person">
-      <email>jacendi@protonmail.com</email>
-      <name>Vladimir Gavrilov</name>
-    </owner>
-    <source type="git">https://bitbucket.org/jacendi/jacendi-overlay</source>
-    <feed>https://bitbucket.org/jacendi/jacendi-overlay/atom</feed>
-  </repo>
   <repo quality="experimental" status="official">
     <name>java</name>
     <description lang="en">Java overlay</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4625,20 +4625,6 @@
     <feed>https://github.com/yandex-gentoo/overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>yoreek</name>
-    <description lang="en">Ebuilds related to nginx webserver modules</description>
-    <homepage>https://cgit.gentoo.org/user/yoreek.git/</homepage>
-    <owner type="person">
-      <email>yoreek@yahoo.com</email>
-      <name>Yuri U.</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/user/yoreek.git</source>
-    <source type="git">git://anongit.gentoo.org/user/yoreek.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/user/yoreek.git</source>
-    <feed>https://cgit.gentoo.org/user/yoreek.git/atom/</feed>
-    <!-- <feed>https://cgit.gentoo.org/user/yoreek.git/rss/</feed> -->
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>yurij-overlay</name>
     <description lang="en">Yurij's overlay</description>
     <homepage>https://github.com/yurijmikhalevich/yurij-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1511,18 +1511,6 @@
     <feed>https://github.com/Pekkari/foxiverlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>fragtoo</name>
-    <description lang="en">My personal Gentoo overlay, mostly related to gaming</description>
-    <homepage>https://github.com/garrhow/fragtoo</homepage>
-    <owner type="person">
-      <email>garrett@mersh.com</email>
-      <name>Garrett Howard</name>
-    </owner>
-    <source type="git">https://github.com/garrhow/fragtoo.git</source>
-    <source type="git">git+ssh://git@github.com/garrhow/fragtoo.git</source>
-    <feed>https://github.com/garrhow/fragtoo/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>fritteli</name>
     <description lang="en">fritteli's Gentoo Overlay</description>
     <homepage>https://github.com/fritteli/gentoo-overlay</homepage>


### PR DESCRIPTION
Common to all of these is that they have a number of failures. Since failures were detected the repositories don't appear to be updated and pings on the QA bugs haven't been acknowledged.

The only standout is 'fragtoo' - the repository was deleted and the owner has said to remove the overlay.