### PR TITLE
repositories: remove keepbot-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2110,18 +2110,6 @@
     <!-- <feed>https://cgit.gentoo.org/proj/kde.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>keepbot-overlay</name>
-    <description lang="en">keepbot's personal ebuild repository</description>
-    <homepage>https://github.com/d-k-ivanov/gentoo-overlay.git</homepage>
-    <owner type="person">
-      <email>d.k.ivanov@live.com</email>
-      <name>Dmitry Ivanov</name>
-    </owner>
-    <source type="git">https://github.com/d-k-ivanov/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/d-k-ivanov/gentoo-overlay.git</source>
-    <feed>https://github.com/d-k-ivanov/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>khoverlay</name>
     <description>Khumba's overlay, mainly Haskell packages</description>
     <homepage>https://gitlab.com/khumba/khoverlay</homepage>


### PR DESCRIPTION
Sadly, I don't have enough time to contribute to gentoo usage.

closes: https://bugs.gentoo.org/902311
