### PR TITLE
repositories.xml: remove 'openwrt' overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2833,17 +2833,6 @@
     <feed>https://github.com/jcaesar/openclonk-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>openwrt</name>
-    <description>Overlay for network configuration packages found in OpenWRT</description>
-    <homepage>https://github.com/pavlix/gentoo-openwrt</homepage>
-    <owner type="person">
-      <email>pavlix@pavlix.net</email>
-      <name>Pavel Šimerda</name>
-    </owner>
-    <source type="git">https://github.com/pavlix/gentoo-openwrt.git</source>
-    <source type="git">git+ssh://git@github.com/pavlix/gentoo-openwrt.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>oubliette</name>
     <description lang="en">personal overlay of forgotten ebuilds</description>
     <homepage>https://github.com/nabbi/oubliette-overlay</homepage>


### PR DESCRIPTION
Owner has indicated that the overlay is unlikely to be updated by them anytime soon.

Closes: https://bugs.gentoo.org/859046