### PR TITLE
repositories: Remove librepilot-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2696,19 +2696,6 @@ FIN
     <source type="git">git://anongit.gentoo.org/user/levenkov.git</source>
     <source type="git">http://cgit.gentooexperimental.org/user/levenkov.git</source>
     <source type="git">git+ssh://git@git.gentoo.org/user/levenkov.git</source>
-  </repo>
-    <repo quality="experimental" status="unofficial">
-    <name>librepilot</name>
-    <description lang="en">Librepilot flight control software overlay</description>
-    <homepage>https://github.com/paul-jewell/librepilot-overlay</homepage>
-    <owner type="person">
-      <email>paul@teulu.org</email>
-      <name>Paul Jewell</name>
-    </owner>
-    <source type="git">https://github.com/paul-jewell/librepilot-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/paul-jewell/librepilot-overlay.git</source>
-    <feed>https://github.com/paul-jewell/librepilot-overlay/commits/master.atom</feed>
-  </repo>
   <repo quality="experimental" status="official">
     <name>libressl</name>
     <description lang="en">LibreSSL ebuilds testing repository</description>


### PR DESCRIPTION
Librepilot is no longer maintained, and does not build due to stale dependencies. Other packages in the overlay are only required for librepilot.