### PR TITLE
repositories: Remove librepilot overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2279,18 +2279,6 @@
     <source type="git">git+ssh://git@github.com/lima-limon-inc/lemon-lime-overlay.git</source>
     <feed>https://github.com/lima-limon-inc/lemon-lime-overlay/commits/master.atom</feed>
   </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>librepilot</name>
-    <description lang="en">Librepilot flight control software overlay</description>
-    <homepage>https://github.com/paul-jewell/librepilot-overlay</homepage>
-    <owner type="person">
-      <email>paul@teulu.org</email>
-      <name>Paul Jewell</name>
-    </owner>
-    <source type="git">https://github.com/paul-jewell/librepilot-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/paul-jewell/librepilot-overlay.git</source>
-    <feed>https://github.com/paul-jewell/librepilot-overlay/commits/master.atom</feed>
-  </repo>
   <repo quality="experimental" status="official">
     <name>libressl</name>
     <description lang="en">LibreSSL ebuilds testing repository</description>


### PR DESCRIPTION
Librepilot is no longer maintained, and does not build due to stale dependencies. Other packages in the overlay are only for librepilot, so removal of the overlay is the best option.