### PR TITLE
repositories: add proaudio-gentoo

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3157,6 +3157,18 @@
     <feed>https://github.com/ppfeufer/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>proaudio-gentoo</name>
+    <description lang="en">New generation ProAudio overlay</description>
+    <homepage>https://github.com/domichel/proaudio-gentoo</homepage>
+    <owner type="person">
+      <email>dominique.c.michel@gmail.com</email>
+      <name>Dominique Michel</name>
+    </owner>
+    <source type="git">https://github.com/domichel/proaudio-gentoo.git</source>
+    <source type="git">git+ssh://git@github.com/domichel/proaudio-gentoo.git</source>
+    <feed>https://github.com/domichel/proaudio-gentoo/commits.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>pross</name>
     <description lang="en">Up to date ck-sources</description>
     <homepage>https://github.com/Pross/pross-overlay</homepage>


### PR DESCRIPTION
Hi,

I done a general cleanup of the old and historical proaudio overlay on TuxFamily, and I put the result on github at https://github.com/domichel/proaudio-gentoo

It would be very nice if the users can use eselect repository with it. If this can contribute to gentoo and make it a better audio pro distribution, it would be nice too and I would be happy to contribute.