### PR TITLE
repositories: add pypi-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3193,6 +3193,18 @@
     <feed>https://github.com/ZeroPointEnergy/gentoo-pyfa-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>pypi</name>
+    <description lang="en">Mirror of PyPI python package repository</description>
+    <homepage>https://github.com/houseofsuns/pypi</homepage>
+    <owner type="person">
+      <email>gentoo@houseofsuns.org</email>
+      <name>houseofsuns</name>
+    </owner>
+    <source type="git">https://github.com/houseofsuns/pypi.git</source>
+    <source type="git">git+ssh://git@github.com/houseofsuns/pypi.git</source>
+    <feed>https://github.com/houseofsuns/pypi/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>pypi-sci</name>
     <description lang="en">Scientific packages from PyPI by the gentoo-pypi-generator</description>
     <homepage>https://github.com/jiegec/gentoo-pypi-sci</homepage>


### PR DESCRIPTION
This is an automatically generated mirror of PyPI.

Note that due to the size and nature of PyPI this mirror has several
limitations:
* only the 65535 most downloaded packages are included to keep the
  repository manageable (the actual number differs somewhat due to
  fluctuation and the next point),
* from each package only the most recent version is provided as ebuild,
* some packages are omitted due to not providing source files or similar
  hindrances, in some cases this means that old versions are included if
  newer versions stopped providing source files,
* even with the mitigations the size of all ebuilds combined is rather
  huge,
* conversion from PyPI metadata to ebuild is not perfect and for example
  may contain dependencies which are actually excluded by additional
  conditions. Additionally package installation may fail due to for
  example stronger quality checks in an eclass. In these cases please
  open an issue. As said, there are lots of packages so there probably
  are some failures still lurking.