### PR TITLE
repositories: remove moulay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2574,18 +2574,6 @@
     <source type="git">git+ssh://git@github.com/vincentdephily/moltonel-ebuilds.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>moulay</name>
-    <description lang="en">yemou's personal overlay</description>
-    <homepage>https://gitlab.com/yemou/moulay</homepage>
-    <owner type="person">
-      <email>yemou@protonmail.com</email>
-      <name>yemou Hannam</name>
-    </owner>
-    <source type="git">https://gitlab.com/yemou/moulay.git</source>
-    <source type="git">git+ssh://git@gitlab.com/yemou/moulay.git</source>
-    <feed>https://gitlab.com/yemou/moulay/commits/master?format=atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>mrtnvgr</name>
     <description lang="en">mrtnvgr's personal overlay</description>
     <homepage>https://github.com/mrtnvgr/gentoo-overlay</homepage>


### PR DESCRIPTION
I haven't updated this overlay in about two years and I don't intend to.