### PR TITLE
repositories: add XaetaCore-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4758,6 +4758,18 @@
     <!-- <feed>https://cgit.gentoo.org/proj/x11.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>XaetaCore</name>
+    <description lang="en">Collection of various missing or modified packages</description>
+    <homepage>https://git.xaetacore.net/jeroenmathon/xaetacore</homepage>
+    <owner type="person">
+      <email>jeroenmathonmac@gmail.com</email>
+      <name>XaetaCore</name>
+    </owner>
+    <source type="git">https://github.com/kabili207/zyrenth-overlay.git</source>
+    <source type="git">git@github.com:kabili207/zyrenth-overlay.git</source>
+    <feed>https://github.com/kabili207/zyrenth-overlay/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>xarblu-overlay</name>
     <description lang="en">Xarblu's personal ebuild overlay</description>
     <homepage>https://github.com/xarblu/xarblu-overlay</homepage>


### PR DESCRIPTION
I have created a repository for packages missing from the other overlays as well as future user requested packages