### PR TITLE
repositories: update khoverlay URLs and description

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2207,15 +2207,15 @@
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>khoverlay</name>
-    <description>Khumba's overlay, mainly Haskell packages</description>
-    <homepage>https://gitlab.com/khumba/khoverlay</homepage>
+    <description>Khumba's overlay, with games, tools, themes, System76 drivers</description>
+    <homepage>https://khumba.net/gentoo/</homepage>
     <owner type="person">
       <email>bog@khumba.net</email>
       <name>Bryan Gardiner</name>
     </owner>
-    <source type="git">https://gitlab.com/khumba/khoverlay.git</source>
-    <source type="git">git+ssh://git@gitlab.com/khumba/khoverlay.git</source>
-    <feed>https://gitlab.com/khumba/khoverlay/commits/master.atom</feed>
+    <source type="git">https://git.sr.ht/~khumba/khoverlay</source>
+    <source type="git">ssh://git@git.sr.ht/~khumba/khoverlay</source>
+    <feed>https://git.sr.ht/~khumba/khoverlay/log/master/rss.xml</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>konsolebox</name>


### PR DESCRIPTION
Hello, I have moved khoverlay to Sourcehut and would like to update the URLs.  Also the description was long out of date, this new one better reflects what is in the repository.

I would appreciate some confirmation the second, SSH source URL, `ssh://git@git.sr.ht/~khumba/khoverlay`.  Should this be `git+ssh://` instead?  A quick search isn't showing any docs for what plus means here.  I see that the few other overlays on Sourcehut all specify `ssh://`.  **Also**, they all have a colon between `git.sr.ht` and the `~user`, which is a copy-paste of what Sourcehut shows in their UI, but is probably wrong; I need to put a slash there instead for the URL to work, `git clone` doesn't like when I put a colon there:

    git clone ssh://git@git.sr.ht/~khumba/khoverlay    # works
    git clone ssh://git@git.sr.ht:~khumba/khoverlay    # doesn't

Thanks!