### PR TITLE
repositories: add swirl (again)

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4182,6 +4182,20 @@
     <source type="rsync">rsync://rsync.gentoo.stealer.net/swegener-overlay/</source>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>swirl</name>
+    <description lang="en">Overlay for software I use or made</description>
+    <homepage>https://git.swurl.xyz/swirl/overlay</homepage>
+    <owner type="person">
+      <email>swurl@swurl.xyz</email>
+      <name>swurl</name>
+    </owner>
+    <source type="git">https://github.com/binex-dsk/ebuilds.git</source>
+    <source type="git">git@github.com:binex-dsk/ebuilds.git</source>
+    <source type="git">https://git.swurl.xyz/swirl/ebuilds.git</source>
+    <source type="git">gitea@git.swurl.xyz:swirl/ebuilds.git</source>
+    <feed>https://github.com/binex-dsk/ebuilds/commits/master.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>SwordArMor</name>
     <description lang="en">Personnal overlay of alarig/SwordArMor</description>
     <homepage>https://git.grifon.fr/alarig/SwordArMor-gentoo-overlay</homepage>


### PR DESCRIPTION
Stale ebuilds have been removed, I started using gentoo again.