### PR TITLE
repositores: add g

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1582,6 +1582,17 @@
     <feed>https://github.com/qwe795138426/fyn-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>g</name>
+    <description lang="en">My personal overlay</description>
+    <homepage>http://splet.sijanec.eu/dir/g.shtml</homepage>
+    <owner type="person">
+      <email>anton@sijanec.eu</email>
+      <name>Anton Luka Šijanec</name>
+    </owner>
+    <source type="git">https://ni.sijanec.eu/sijanec/g</source>
+    <feed>https://ni.sijanec.eu/sijanec/g/atom/?h=master</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>gamerlay</name>
     <description>
       Gamers overlay for all various games. Not related with games team.


### PR DESCRIPTION
This is my personal ebuild repository. It currently contains just two programs, pamldapd (Go software for exposing PAM via LDAP) and searc, (experimental and broken google search proxy).

Off-topic: since XMLLINT_INDENT environment variable is not specified in files/overlays/Makefile, `make check` may fail if user manually set `XMLLINT_INDENT=$'\t'` or similar.