### PR TITLE
repositories: add vimproved

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4631,6 +4631,18 @@
     <feed>https://github.com/vifino/vifino-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>vimproved</name>
+    <description lang="en">Bringing you Pro Audio Software, Wayland ricing, and Yuri Visual Novels since 2023!</description>
+    <homepage>https://codeberg.org/vimproved/overlay</homepage>
+    <owner type="person">
+      <email>vimproved@inventati.org</email>
+      <name>Violet Purcell</name>
+    </owner>
+    <source type="git">https://codeberg.org/vimproved/overlay.git</source>
+    <source type="git">git@codeberg.org:vimproved/overlay.git</source>
+    <feed>https://codeberg.org/vimproved/overlay.rss</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>violet-funk</name>
     <description lang="en">Gentoo overlay for FNF-related ebuilds as well as some useful software.</description>
     <homepage>https://github.com/MagelessMayhem/violet-funk</homepage>


### PR DESCRIPTION
Not sure why I didn't do this earlier. I generally try to hold myself to the same standards as ::gentoo here (no bundling, no conditional patching, etc). Ebuilds are primarily tested on musl+llvm, so there may be occasional glibc/gcc issues.