### PR TITLE
repositories: remove earshark overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1098,18 +1098,6 @@
     <feed>https://github.com/Dwosky/Dwosky-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>earshark</name>
-    <description>personal overlay, mostly games related</description>
-    <homepage>https://github.com/Chemrat/overlay</homepage>
-    <owner type="person">
-      <email>jazzvoid@gmail.com</email>
-      <name>Valeriy</name>
-    </owner>
-    <source type="git">https://github.com/Chemrat/overlay.git</source>
-    <source type="git">git+ssh://git@github.com/Chemrat/overlay.git</source>
-    <feed>https://github.com/Chemrat/overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>edgets</name>
     <description lang="en">Gentoo overlay that brings you the newest versions of modern software.</description>
     <homepage>https://github.com/BlueManCZ/edgets</homepage>


### PR DESCRIPTION
It is no longer maintained