### PR TITLE
repositories: add thuis overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4535,6 +4535,17 @@
     <feed>https://github.com/osirisinferi/third-party-certbot-plugins/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>thuis</name>
+    <description lang="en">An overlay that feels like home</description>
+    <homepage>https://codeberg.org/emneo/thuis</homepage>
+    <owner type="person">
+      <email>emneo@kreog.com</email>
+      <name>Emily Flion</name>
+    </owner>
+    <source type="git">git+https://codeberg.org/emneo/thuis.git</source>
+    <feed>https://codeberg.org/emneo/thuis.rss</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>tmacedo</name>
     <description>User Overlay</description>
     <homepage>https://github.com/tmacedo/portage</homepage>


### PR DESCRIPTION
Currently contains libcsfml, git-who and flecs
But some more will be added later, like waylock and liskvork.