### PR TITLE
uid-gid.txt: assign 547 to derper

### DIFF
--- a/files/uid-gid.txt
+++ b/files/uid-gid.txt
@@ -640,6 +640,7 @@ sssd				543		543		acct
 stalwart-mail			544		544		acct		Used by net-mail/stalwart
 gnome-remote-desktop		545		545		acct		Used by net-misc/gnome-remote-desktop
 tlsrpt-reporter			546		546		acct		Used by net-mail/tlsrpt-reporter
+derper				547		547		acct		Used by net-vpn/derper
 
 -				750..999	750..999	reserved	Dynamic allocation by user.eclass. Do not use!
 -				1000..60000	1000..60000	reserved	`UID_MIN`..`UID_MAX` / `GID_MIN`..`GID_MAX` in login.defs


### PR DESCRIPTION
request new ID for net-vpn/derper for security, see PR and bug
https://github.com/gentoo/gentoo/pull/41165
https://bugs.gentoo.org/951451