### PR TITLE
repositories: Update Dinolay overlay's information (bugs/961367)

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1020,15 +1020,15 @@
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>dinolay</name>
-    <description lang="en">TruncatedDinosour's overlay</description>
-    <homepage>https://github.com/TruncatedDinosour/dinolay</homepage>
+    <description lang="en">ar1ja's overlay</description>
+    <homepage>https://git.ari.lt/ari/dinolay</homepage>
     <owner type="person">
-      <email>ari.web.xyz@gmail.com</email>
-      <name>Ari Archer</name>
+      <email>ari@ari.lt</email>
+      <name>Arija A.</name>
     </owner>
-    <source type="git">https://github.com/TruncatedDinosour/dinolay.git</source>
-    <source type="git">git@github.com:TruncatedDinosour/dinolay.git</source>
-    <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
+    <source type="git">https://git.ari.lt/ari/dinolay.git</source>
+    <source type="git">git@git.ari.lt/ari/dinolay.git</source>
+    <feed>https://git.ari.lt/ari/dinolay/rss/branch/main</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>displacer</name>


### PR DESCRIPTION
- Changed GitHub username (TruncatedDinoSour => ar1ja)
- Changed URL: now self-hosting at https://git.ari.lt/
- Changed E-mail and name