### PR TITLE
repositories: remove vgist overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4859,18 +4859,6 @@
     <feed>https://github.com/thiagovespa/vespa-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>vGist</name>
-    <description>vGist overlay, for personal use.</description>
-    <homepage>https://github.com/vgist/vgist-overlay</homepage>
-    <owner type="person">
-      <email>admin@mail.havee.me</email>
-      <name>havee</name>
-    </owner>
-    <source type="git">https://github.com/vgist/vgist-overlay.git</source>
-    <source type="git">git@github.com:vgist/vgist-overlay.git</source>
-    <feed>https://github.com/vgist/vgist-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>vifino-overlay</name>
     <description lang="en">vifino's personal overlay</description>
     <homepage>https://github.com/vifino/vifino-overlay</homepage>


### PR DESCRIPTION
I don't maintain this overlay anymore.