### PR TITLE
repositories: add another-brave-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -362,6 +362,17 @@
     <source type="git">git+ssh://git@github.com/Anoncheg1/anonch-overlay.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>another-brave-overlay</name>
+    <description lang="en">Overlay for automatically generated Brave web browser ebuilds</description>
+    <homepage>https://github.com/falbrechtskirchinger/another-brave-overlay</homepage>
+    <owner type="person">
+      <email>falbrechtskirchinger@gmail.com</email>
+      <name>Florian Albrechtskirchinger</name>
+    </owner>
+    <source type="git">https://github.com/falbrechtskirchinger/another-brave-overlay.git</source>
+    <feed>https://github.com/falbrechtskirchinger/another-brave-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>antons-matrix-overlay</name>
     <description lang="en">Packages related to matrix.org messaging system</description>
     <homepage>https://gitlab.com/anton.molyboha.group/gentoo/overlays/matrix</homepage>


### PR DESCRIPTION
### [another-brave-overlay](https://github.com/falbrechtskirchinger/another-brave-overlay)

This overlay uses GitHub workflows to automatically generate ebuilds for the Brave web browser. Although an existing brave-overlay is actively updated, its maintainer has been unresponsive to issues. I submitted a merge request to fix a problem, but received no response.

This particular issue could have been avoided if the brave-overlay ebuilds tracked the Google Chrome ebuilds in ::gentoo, which they are clearly based on (as are mine). another-brave-overlay explicitly tracks divergence from the ::gentoo Google Chrome ebuilds and uses a scheduled workflow to alert me when they need to be resynced.

I chose to create a new overlay rather than contribute to GURU, as automated daily commits may not be welcome - or even be against the rules (which I haven’t re-read to check).

There is still room for improvement. Planned enhancements include:

- Removing `message.json` files for languages not selected by the user (in progress via a chromium-2 wrapper eclass).
- Committing new ebuilds to a temporary branch, testing, then merging to main only if successful.
- Collecting and reporting QA notices during testing.
- Running `pkgcheck scan` as part of a workflow.

I’ll address these over time, but don't consider any of them critical for inclusion.

Please let me know if I missed anything.