### PR TITLE
Remove old broken overlays

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2471,17 +2471,6 @@
     <source type="git">git+ssh://git@codeberg.org:librewolf/gentoo.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>liftm</name>
-    <description lang="en">Personal Overlay</description>
-    <owner type="person">
-      <email>gentoobug@liftm.de</email>
-      <name>Julius Michaelis</name>
-    </owner>
-    <source type="git">https://github.com/jcaesar/liftm-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/jcaesar/liftm-overlay.git</source>
-    <feed>https://github.com/jcaesar/liftm-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>lilium</name>
     <description lang="en">owl4ce's personal portage overlay for ebuild repairs or feature-upgrades</description>
     <homepage>https://github.com/owl4ce/lilium</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3230,18 +3230,6 @@
     <feed>https://gitlab.com/Parona/parona-overlay/-/commits/master?format=atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>pdilung</name>
-    <description lang="en">Personal Gentoo overlay of Pavol Dilung</description>
-    <homepage>https://github.com/pdilung/gentoo-overlay/</homepage>
-    <owner type="person">
-      <email>pavol.dilung@gmail.com</email>
-      <name>Pavol Dilung</name>
-    </owner>
-    <source type="git">https://github.com/pdilung/gentoo-overlay.git</source>
-    <source type="git">git@github.com:pdilung/gentoo-overlay.git</source>
-    <feed>https://github.com/pdilung/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>peec</name>
     <description lang="en">Personal Gentoo overlay of Petre Rodan</description>
     <homepage>https://codeberg.org/subDIMENSION/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2102,18 +2102,6 @@
     <feed>https://github.com/iritmaximus/overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>ixit</name>
-    <description lang="en">iXit overlay</description>
-    <homepage>https://github.com/okias/ixit</homepage>
-    <owner type="person">
-      <email>david@ixit.cz</email>
-      <name>David Heidelberger</name>
-    </owner>
-    <source type="git">https://github.com/okias/ixit.git</source>
-    <source type="git">git@github.com:okias/ixit.git</source>
-    <feed>https://github.com/okias/ixit/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>jabuxas</name>
     <description lang="en">jabuxas personal overlay</description>
     <homepage>https://github.com/jabuxas/overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -184,17 +184,6 @@
     <feed>https://github.com/alatarum/alatar-lay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>alesharik</name>
-    <description lang="en">Gentoo portage overlay of alesharik</description>
-    <homepage>https://github.com/alesharik/alesharik-overlay</homepage>
-    <owner type="person">
-      <email>alesharik4@gmail.com</email>
-      <name>Aleksei Arsenev</name>
-    </owner>
-    <source type="git">https://github.com/alesharik/alesharik-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/alesharik/alesharik-overlay.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>AlexandreFournier</name>
     <description lang="en">Alexandre Fournier's personal overlay</description>
     <homepage>https://github.com/AlexandreFournier/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -160,18 +160,6 @@
     <!-- <feed>https://cgit.gentoo.org/dev/ago.git/rss/</feed> -->
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>ahyangyi-overlay</name>
-    <description lang="en">Ahyangyi's overlay</description>
-    <homepage>https://github.com/ahyangyi/ahyangyi-overlay</homepage>
-    <owner type="person">
-      <email>ahyangyi@gmail.com</email>
-      <name>Yi Yang</name>
-    </owner>
-    <source type="git">https://github.com/ahyangyi/ahyangyi-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/ahyangyi/ahyangyi-overlay.git</source>
-    <feed>https://github.com/ahyangyi/ahyangyi-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>akater</name>
     <description lang="en">Personal ebuild repository.  Emacs, Lisp, minimalism.</description>
     <homepage>https://gitlab.com/akater/ebuilds</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1031,20 +1031,6 @@
     <feed>https://github.com/TruncatedDinosour/dinolay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>displacer</name>
-    <description lang="en">Fixes and new unstable packages</description>
-    <homepage>https://cgit.gentoo.org/user/displacer.git/</homepage>
-    <owner type="person">
-      <email>disinbox@gmail.com</email>
-      <name>Igor Ulyanov</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/user/displacer.git</source>
-    <source type="git">git://anongit.gentoo.org/user/displacer.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/user/displacer.git</source>
-    <feed>https://cgit.gentoo.org/user/displacer.git/atom/</feed>
-    <!-- <feed>https://cgit.gentoo.org/user/displacer.git/rss/</feed> -->
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>distros</name>
     <description>Calculate Linux Profiles</description>
     <homepage>http://www.calculate-linux.org</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3969,18 +3969,6 @@
     <feed>https://github.com/tx00100xt/serioussam-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>setkeh</name>
-    <description lang="en">setkeh maintained ebuilds</description>
-    <homepage>https://github.com/setkeh/Portage-Overlay</homepage>
-    <owner type="person">
-      <email>setkeh@gmail.com</email>
-      <name>James (setkeh) Griffis</name>
-    </owner>
-    <source type="git">https://github.com/setkeh/Portage-Overlay.git</source>
-    <source type="git">git+ssh://git@github.com/setkeh/Portage-Overlay.git</source>
-    <feed>https://github.com/setkeh/Portage-Overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>sevz</name>
     <description lang="en">Personal Custom Gentoo Overlay.</description>
     <homepage>https://gitlab.com/sevz17/sevz-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3356,20 +3356,6 @@
     <source type="git">git+ssh://git@github.com/antonsviridenko/pica-pica-gentoo-overlay.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>pigfoot</name>
-    <description lang="en">Ebuilds for experimental packages and chinese patches</description>
-    <homepage>https://cgit.gentoo.org/user/pigfoot.git/</homepage>
-    <owner type="person">
-      <email>pigfoot@gmail.com</email>
-      <name>pigfoot</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/user/pigfoot.git</source>
-    <source type="git">git://anongit.gentoo.org/user/pigfoot.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/user/pigfoot.git</source>
-    <feed>https://cgit.gentoo.org/user/pigfoot.git/atom/</feed>
-    <!-- <feed>https://cgit.gentoo.org/user/pigfoot.git/rss/</feed> -->
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>pingwho-overlay</name>
     <description lang="en">Gentoo Linux overlay @pingwho.org</description>
     <homepage>https://github.com/jaypeche/pingwho-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4186,18 +4186,6 @@
     <feed>https://cgit.gentoo.org/repo/user/ssnb.git/atom/</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>sspreitz</name>
-    <description lang="en">My Gentoo repository and ebuilds</description>
-    <homepage>https://github.com/sspreitzer/gentoo-repo</homepage>
-    <owner type="person">
-      <email>sspreitz@redhat.com</email>
-      <name>Sascha Spreitzer</name>
-    </owner>
-    <source type="git">https://github.com/sspreitzer/gentoo-repo.git</source>
-    <source type="git">git+ssh://git@github.com/sspreitzer/gentoo-repo.git</source>
-    <feed>https://github.com/sspreitzer/gentoo-repo/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>steam-overlay</name>
     <description lang="en">Gentoo overlay for Valve's Steam client and Steam-based games</description>
     <homepage>https://github.com/anyc/steam-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -305,18 +305,6 @@
     <source type="git">git+ssh://git@github.com/anders-larsson/gentoo-overlay.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>andrey_utkin</name>
-    <description lang="en">Developer overlay</description>
-    <homepage>https://github.com/andrey-utkin/gentoo-overlay.git</homepage>
-    <owner type="person">
-      <email>andrey_utkin@gentoo.org</email>
-      <name>andrey_utkin</name>
-    </owner>
-    <source type="git">https://github.com/andrey-utkin/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/andrey-utkin/gentoo-overlay.git</source>
-    <feed>https://github.com/andrey-utkin/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>anomen</name>
     <description lang="en">anomen's personal Gentoo overlay</description>
     <homepage>https://github.com/anomen-s/anomen-overlay</homepage>


### PR DESCRIPTION
These are all overlays that have had QA bugs open since 2022 or 2023 and no action has been taken on them.