### PR TITLE
remove more overlays that appear unmaintained

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2808,18 +2808,6 @@
     <feed>https://github.com/Nowa-Ammerlaan/natinst/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>nelson-graca</name>
-    <description lang="en">Nelson Graça personal Overlay</description>
-    <homepage>https://github.com/nelsongraca/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>graca.nelson@gmail.com</email>
-      <name>Nelson Graça</name>
-    </owner>
-    <source type="git">https://github.com/nelsongraca/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/nelsongraca/gentoo-overlay.git</source>
-    <feed>https://github.com/nelsongraca/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>nest</name>
     <description lang="en">Personal Gentoo overlay</description>
     <homepage>https://github.com/SpiderX/portage-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3845,18 +3845,6 @@
     <feed>https://github.com/ArsenShnurkov/shnurise/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>simonvanderveldt</name>
-    <description lang="en">Personal Gentoo overlay focused on music production and engineering applications</description>
-    <homepage>https://github.com/simonvanderveldt/simonvanderveldt-overlay</homepage>
-    <owner type="person">
-      <email>simon.vanderveldt@gmail.com</email>
-      <name>Simon van der Veldt</name>
-    </owner>
-    <source type="git">https://github.com/simonvanderveldt/simonvanderveldt-overlay.git</source>
-    <source type="git">git@github.com:simonvanderveldt/simonvanderveldt-overlay.git</source>
-    <feed>https://github.com/simonvanderveldt/simonvanderveldt-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>sinustrom</name>
     <description lang="en">Sinustrom Gentoo Overlay</description>
     <homepage>https://github.com/zpuskas/sinustrom-gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2840,18 +2840,6 @@
     <source type="git">git+ssh://git@gitlab.com/xgqt/myov.git</source>
     <feed>https://gitlab.com/xgqt/myov/commits/master.atom</feed>
   </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>myrvolay</name>
-    <description lang="en">myrvogna's personal Gentoo overlay</description>
-    <homepage>https://github.com/myrvogna/myrvolay</homepage>
-    <owner type="person">
-      <email>myrvogna@electrosphe.re</email>
-      <name>Octiabrina Terrien-Puig</name>
-    </owner>
-    <source type="git">https://github.com/myrvogna/myrvolay.git</source>
-    <source type="git">git@github.com:myrvogna/myrvolay.git</source>
-    <feed>https://github.com/myrvogna/myrvolay/commits/main.atom</feed>
-  </repo>
   <repo quality="experimental" status="official">
     <name>mysql</name>
     <description lang="en">Gentoo MySQL overlay</description>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2108,20 +2108,6 @@
     <source type="git">git+ssh://git@github.com/Jannis234/jm-overlay.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>jmbsvicetto</name>
-    <description>Jorge Manuel B. S. Vicetto developer overlay</description>
-    <homepage>https://cgit.gentoo.org/repo/dev/jmbsvicetto.git</homepage>
-    <owner type="person">
-      <email>jmbsvicetto@gentoo.org</email>
-      <name>Jorge Manuel B. S. Vicetto</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/repo/dev/jmbsvicetto.git</source>
-    <source type="git">git://anongit.gentoo.org/repo/dev/jmbsvicetto.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/repo/dev/jmbsvicetto.git</source>
-    <feed>https://cgit.gentoo.org/repo/dev/jmbsvicetto.git/atom/</feed>
-    <!-- <feed>https://cgit.gentoo.org/repo/dev/jmbsvicetto.git/rss/</feed> -->
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>joecool-overlay</name>
     <description lang="en">joecool's personal overlay</description>
     <homepage>https://github.com/joecool1029/joecool-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -809,16 +809,6 @@
     <feed>https://github.com/osirisinferi/certbot-dns-plugins-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>cg</name>
-    <description>Computer graphics ebuilds for gentoo</description>
-    <homepage>https://github.com/brothermechanic/cg</homepage>
-    <owner type="person">
-      <email>brothermechanic@gmail.com</email>
-    </owner>
-    <source type="git">https://github.com/brothermechanic/cg.git</source>
-    <source type="git">git+ssh://git@github.com/brothermechanic/cg.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>chiyuki-overlay</name>
     <description lang="en">Chiyuki's Personal Gentoo Linux Overlay</description>
     <homepage>https://github.com/IllyaTheHath/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3569,17 +3569,6 @@
     <feed>https://gitlab.com/gentoo-racket/gentoo-racket-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>raiagent</name>
-    <description lang="en">Well-documented ebuilds en-route to a bandersnatch near you</description>
-    <homepage>https://github.com/leycec/raiagent</homepage>
-    <owner type="person">
-      <email>leycec@gmail.com</email>
-      <name>Cecil Curry</name>
-    </owner>
-    <source type="git">https://github.com/leycec/raiagent.git</source>
-    <source type="git">git+ssh://git@github.com/leycec/raiagent.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>rasdark</name>
     <description>rasdark personal overlay</description>
     <homepage>https://github.com/rasdark/overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4602,18 +4602,6 @@
     <feed>https://github.com/DakEnviy/underworld-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>unity-gentoo</name>
-    <description lang="en">Overlay to install the Unity desktop</description>
-    <homepage>https://github.com/shiznix/unity-gentoo</homepage>
-    <owner type="person">
-      <email>rickfharris@yahoo.com.au</email>
-      <name>Rick Harris</name>
-    </owner>
-    <source type="git">https://github.com/shiznix/unity-gentoo.git</source>
-    <source type="git">git+ssh://git@github.com/shiznix/unity-gentoo.git</source>
-    <feed>https://github.com/shiznix/unity-gentoo/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>unmojang-overlay</name>
     <description lang="en">Gentoo overlay for unmojang projects</description>
     <homepage>https://github.com/unmojang/unmojang-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1346,15 +1346,6 @@
     <feed>https://github.com/ferki/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>fidonet</name>
-    <description lang="en">Overlay of Benny Pedersen</description>
-    <owner type="person">
-      <email>me@junc.eu</email>
-      <name>Benny Pedersen</name>
-    </owner>
-    <source type="rsync">rsync://fido.junc.eu/fidonet/</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>FireBurn</name>
     <description lang="en">32bit ebuilds (libdrm, mesa, libx11, mesa-progs, ..)</description>
     <homepage>https://github.com/FireBurn/Overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2633,18 +2633,6 @@
     <feed>https://gitlab.com/menelkir/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>metahax</name>
-    <description lang="en">Some ebuilds that didn't seem to exist yet.</description>
-    <homepage>https://github.com/metafarion/metahax</homepage>
-    <owner type="person">
-      <email>miles@ctrl-shift.net</email>
-      <name>Miles V.</name>
-    </owner>
-    <source type="git">https://github.com/metafarion/metahax.git</source>
-    <source type="git">git+ssh://git@github.com/metafarion/metahax.git</source>
-    <feed>https://github.com/metafarion/metahax/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>Miezhiko</name>
     <description>Miezhiko personal overlay</description>
     <homepage>https://github.com/Miezhiko/Overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3401,18 +3401,6 @@
     <feed>https://github.com/damiandudycz/ps3-gentoo-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>pyfa</name>
-    <description lang="en">Newest versions of Pyfa (Python fitting assistant for EVE Online)</description>
-    <homepage>https://github.com/ZeroPointEnergy/gentoo-pyfa-overlay</homepage>
-    <owner type="person">
-      <email>a.zuber@gmx.ch</email>
-      <name>Andreas Zuber</name>
-    </owner>
-    <source type="git">https://github.com/ZeroPointEnergy/gentoo-pyfa-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/ZeroPointEnergy/gentoo-pyfa-overlay.git</source>
-    <feed>https://github.com/ZeroPointEnergy/gentoo-pyfa-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>pypi</name>
     <description lang="en">Mirror of PyPI python package repository</description>
     <homepage>https://github.com/houseofsuns/pypi</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -889,18 +889,6 @@
     <feed>https://github.com/dargor/dargor_gentoo_overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>darkelf</name>
-    <description lang="en">Overlay focusing on improved user experience for working in darkness on Xfce or zsh (including vim)</description>
-    <homepage>https://cgit.gentoo.org/repo/user/darkelf.git</homepage>
-    <owner type="person">
-      <email>sur3@gmx.de</email>
-      <name>Simon</name>
-    </owner>
-    <source type="git">https://anongit.gentoo.org/git/repo/user/darkelf.git</source>
-    <source type="git">git+ssh://git@git.gentoo.org/repo/user/darkelf.git</source>
-    <feed>https://cgit.gentoo.org/repo/user/darkelf.git/atom/</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>darthgandalf-overlay</name>
     <description lang="en">Personal overlay</description>
     <homepage>https://github.com/DarthGandalf/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -373,18 +373,6 @@
     <feed>https://gitlab.com/APN-Pucky/gentoo-apn/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>apriluwu</name>
-    <description lang="en">apriluwu's personal overlay</description>
-    <homepage>https://github.com/apriluwu/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>aaprilthemonth@gmail.com</email>
-      <name>April C.</name>
-    </owner>
-    <source type="git">https://github.com/apriluwu/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/apriluwu/gentoo-overlay.git</source>
-    <feed>https://github.com/apriluwu/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>ArchFeh</name>
     <description lang="en">ArchFeh's personal overlay</description>
     <homepage>https://github.com/ArchFeh/ArchFeh-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2118,16 +2118,6 @@
     <feed>https://github.com/jjakob/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>jkolo</name>
-    <description lang="en">Jerzy Kolosowski's Gentoo overlay</description>
-    <homepage>https://git.kolosowscy.pl/jurek/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>jerzy@kolosowscy.pl</email>
-      <name>Jerzy Kolosowski</name>
-    </owner>
-    <source type="git">https://git.kolosowscy.pl/jurek/gentoo-overlay.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>jl1990</name>
     <description lang="en">jl1990's Custom Gentoo Overlay.</description>
     <homepage>https://github.com/jl1990/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2598,18 +2598,6 @@
     <feed>https://github.com/Miezhiko/Overlay/commits/mawa.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>milos-rs</name>
-    <description>A pocket repository for few unavailable packages</description>
-    <homepage>https://github.com/milos-rs/gentoo-overlay</homepage>
-    <owner type="person">
-      <email>milos.om.dj@gmail.com</email>
-      <name>Miloš E. Đurđević</name>
-    </owner>
-    <source type="git">https://github.com/milos-rs/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/milos-rs/gentoo-overlay.git</source>
-    <feed>https://github.com/milos-rs/gentoo-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>mim</name>
     <description lang="en">Aliaksei Urbanski's personal overlay</description>
     <homepage>https://github.com/Jamim/gentoo-overlay</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3306,18 +3306,6 @@
     <feed>https://github.com/domichel/proaudio-gentoo/commits.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>pross</name>
-    <description lang="en">Up to date ck-sources</description>
-    <homepage>https://github.com/Pross/pross-overlay</homepage>
-    <owner type="person">
-      <email>pross@pross.org.uk</email>
-      <name>Simon Prosser</name>
-    </owner>
-    <source type="git">https://github.com/Pross/pross-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/Pross/pross-overlay.git</source>
-    <feed>https://github.com/Pross/pross-overlay/commits/master.atom</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>ps3</name>
     <description lang="en">Ebuilds for Gentoo on the PlayStation 3.</description>
     <homepage>https://github.com/damiandudycz/ps3</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -4260,17 +4260,6 @@
     <source type="git">gitea@git.swurl.xyz:swirl/ebuilds.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>SwordArMor</name>
-    <description lang="en">Personnal overlay of alarig/SwordArMor</description>
-    <homepage>https://git.grifon.fr/alarig/SwordArMor-gentoo-overlay</homepage>
-    <owner type="person">
-      <email>alarig@swordarmor.fr</email>
-      <name>Alarig Le Lay</name>
-    </owner>
-    <source type="git">https://git.grifon.fr/alarig/SwordArMor-gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@git.grifon.fr:alarig/SwordArMor-gentoo-overlay.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>Systole</name>
     <description lang="en">Overlay for the Systole OS</description>
     <homepage>https://github.com/SystoleOS</homepage>


### PR DESCRIPTION
These are all overlays that have had open bugs since 2022-2023 (except raiagent), and haven't seen any response on bugzilla.