### PR TITLE
repositories: add ruizhi-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3850,6 +3850,18 @@
     <source type="git">https://github.com/Ruixi-rebirth/ruixi-overlay.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>ruizhi-overlay</name>
+    <description lang="en">Personal Gentoo overlay maintained by Ruizhi Zhong</description>
+    <homepage>https://github.com/ruizhi-lab/gentoo-overlay</homepage>
+    <owner type="person">
+      <email>ruizhi.zhong88@gmail.com</email>
+      <name>Ruizhi Zhong</name>
+    </owner>
+    <source type="git">https://github.com/ruizhi-lab/gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/ruizhi-lab/gentoo-overlay.git</source>
+    <feed>https://github.com/ruizhi-lab/gentoo-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>ryans</name>
     <description lang="en">Personal ebuild repository.</description>
     <homepage>https://github.com/bekcpear/ryans-repos</homepage>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3858,7 +3858,6 @@
       <name>Ruizhi Zhong</name>
     </owner>
     <source type="git">https://github.com/ruizhi-lab/gentoo-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/ruizhi-lab/gentoo-overlay.git</source>
     <feed>https://github.com/ruizhi-lab/gentoo-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">


### PR DESCRIPTION
Add `ruizhi-overlay` to the Gentoo repository list.

Repository details:

- Name: `ruizhi-overlay`
- Homepage: https://github.com/ruizhi-lab/gentoo-overlay
- Source: https://github.com/ruizhi-lab/gentoo-overlay.git
- Owner: Ruizhi Zhong (`ruizhi.zhong88@gmail.com`)

Local checks performed:

- Overlay ebuild shell syntax check
- Overlay `metadata.xml` `xmllint` check
- Overlay `pkgcheck scan` on `gentoo-cow`
- `api-gentoo-org` repositories XML DTD/XSD validation
- `repositories-checker.py` with Bugzilla email validation
