### PR TITLE
repositories: add rato-verlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3663,6 +3663,18 @@
     <feed>https://git.ratigorsk-12.ru/gentoo/ratigorsk-auto/rss/branch/master</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>rato-verlay</name>
+    <description lang="en">Gentoo overlay shipping Kiro IDE and CLI, Amazon SSM Agent, CloudWatch Agent, EFS mount helper, Amazon DCV server and viewer, and VictoriaMetrics. Validated daily on a real Gentoo instance.</description>
+    <homepage>https://github.com/RaminTorabi/rato-verlay</homepage>
+    <owner type="person">
+      <email>gentoo@torabi.de</email>
+      <name>Ramin Torabi</name>
+    </owner>
+    <source type="git">https://github.com/RaminTorabi/rato-verlay.git</source>
+    <source type="git">git+ssh://git@github.com/RaminTorabi/rato-verlay.git</source>
+    <feed>https://github.com/RaminTorabi/rato-verlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>raw</name>
     <description>some raw stuff</description>
     <homepage>https://github.com/mahatma-kaganovich/raw</homepage>


### PR DESCRIPTION
Adds the rato-verlay overlay to the repositories list.

* repository: https://github.com/RaminTorabi/rato-verlay
* owner: Ramin Torabi <gentoo@torabi.de>
* description: Kiro IDE and CLI, Amazon SSM Agent, CloudWatch Agent,
  EFS mount helper, Amazon DCV server and viewer, VictoriaMetrics,
  on ~amd64. Validated daily by a pipeline that emerges every bumped
  ebuild on a real Gentoo instance before promoting to main.

QA:
* metadata/layout.conf has masters = gentoo
* profiles/repo_name and profiles/categories present
* every package has metadata.xml with maintainer
* GPL-2 LICENSE in repo root with carve-out for upstream distfiles
* RESTRICT="strip mirror bindist" on every binary-only ebuild