### PR TITLE
repositories: add gurov-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1937,6 +1937,18 @@
     <source type="git">git@github.com:uleysky/gsview-overlay.git</source>
     <feed>https://github.com/uleysky/gsview-overlay/commits/master.atom</feed>
   </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>gurov-overlay</name>
+    <description lang="en">Gurov's personal ebuild overlay</description>
+    <homepage>https://github.com/Gur0v/gurov-overlay</homepage>
+    <owner type="person">
+      <email>gurov@disroot.org</email>
+      <name>Gurov</name>
+    </owner>
+    <source type="git">https://github.com/Gur0v/gurov-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/Gur0v/gurov-overlay.git</source>
+    <feed>https://github.com/Gur0v/gurov-overlay/commits/main.atom</feed>
+  </repo>
   <repo quality="experimental" status="official">
     <name>guru</name>
     <description lang="en">GURU: Ebuild repository entirely maintained by Gentoo users</description>
@@ -1954,18 +1966,6 @@
     <source type="git">https://anongit.gentoo.org/git/repo/proj/guru.git</source>
     <source type="git">git+ssh://git@git.gentoo.org/repo/proj/guru.git</source>
     <feed>https://cgit.gentoo.org/repo/proj/guru.git/atom/</feed>
-  </repo>
-  <repo quality="experimental" status="unofficial">
-    <name>gurov-overlay</name>
-    <description lang="en">Gurov's personal ebuild overlay</description>
-    <homepage>https://github.com/Gur0v/gurov-overlay</homepage>
-    <owner type="person">
-      <email>gurov@disroot.org</email>
-      <name>Gurov</name>
-    </owner>
-    <source type="git">https://github.com/Gur0v/gurov-overlay.git</source>
-    <source type="git">git+ssh://git@github.com/Gur0v/gurov-overlay.git</source>
-    <feed>https://github.com/Gur0v/gurov-overlay/commits/main.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>ha-bleeding-edge</name>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1956,6 +1956,18 @@
     <feed>https://cgit.gentoo.org/repo/proj/guru.git/atom/</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>gurov-overlay</name>
+    <description lang="en">Gurov's personal ebuild overlay</description>
+    <homepage>https://github.com/Gur0v/gurov-overlay</homepage>
+    <owner type="person">
+      <email>gurov@disroot.org</email>
+      <name>Gurov</name>
+    </owner>
+    <source type="git">https://github.com/Gur0v/gurov-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/Gur0v/gurov-overlay.git</source>
+    <feed>https://github.com/Gur0v/gurov-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>ha-bleeding-edge</name>
     <description lang="en">Home Assistant bleeding edge repository</description>
     <homepage>https://github.com/tabascoz/ha-bleeding-edge</homepage>


### PR DESCRIPTION
Adds the gurov-overlay overlay to the repositories list.

* **repository:** https://github.com/Gur0v/gurov-overlay
* **owner:** Gurov <gurov@disroot.org>
* **description:** Gurov's personal ebuild overlay

### Included Packages

* `net-misc/anydesk`
* `app-crypt/veracrypt`
* `sys-apps/bubblejail`
* `net-libs/bun`
* `gui-apps/dozed`
* `media-sound/easyeffects`
* `gui-apps/emptty`
* `app-misc/ente-auth`
* `net-im/equibop`
* `app-portage/flagger`
* `dev-python/ftputil`
* `gui-apps/gearlever`
* `media-video/gpu-screen-recorder-notification`
* `media-video/gpu-screen-recorder-ui`
* `www-client/helium-browser-bin`
* `media-libs/libmysofa`
* `dev-util/nvchecker`
* `dev-python/desktop-entry-lib`
* `net-im/viber`
* `net-im/discord-ptb`

### QA

* `metadata/layout.conf` has `masters = gentoo`
* `profiles/repo_name` and `profiles/categories` are present
* `thin-manifests = true` is enabled
* Validated locally with `pkgcheck scan .`