### PR TITLE
repositories: add eventb-rossi

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -1346,6 +1346,17 @@
     <feed>https://github.com/eugene-bright/eugene-bright-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>eventb-rossi</name>
+    <description lang="en">Event-B and B-method formal modelling tools</description>
+    <homepage>https://github.com/eventb-rossi/gentoo-overlay</homepage>
+    <owner type="person">
+      <email>efremov@linux.com</email>
+      <name>Denis Efremov</name>
+    </owner>
+    <source type="git">https://github.com/eventb-rossi/gentoo-overlay.git</source>
+    <feed>https://github.com/eventb-rossi/gentoo-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>ex_repo</name>
     <description lang="en">Arniiiii's overlay. Mostly C++ related.</description>
     <homepage>https://github.com/Arniiiii/ex_repo</homepage>


### PR DESCRIPTION
Adds the eventb-rossi overlay to the repositories list.

* repository: https://github.com/eventb-rossi/gentoo-overlay
* owner: Denis Efremov <efremov@linux.com>
* description: Event-B and B-method formal modelling tools (Rodin,
  ProB, Atelier B, and related verification utilities).