### PR TITLE
Add precizer overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3546,6 +3546,18 @@
     <feed>https://github.com/ppfeufer/gentoo-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>precizer</name>
+    <description lang="en">Gentoo overlay for Precizer, a lightweight file integrity verification and comparison tool</description>
+    <homepage>https://github.com/precizer/gentoo-overlay</homepage>
+    <owner type="person">
+      <email>jpy95dg6@anonaddy.com</email>
+      <name>Dennis Razumovsky</name>
+    </owner>
+    <source type="git">https://github.com/precizer/gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/precizer/gentoo-overlay.git</source>
+    <feed>https://github.com/precizer/gentoo-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>proaudio-gentoo</name>
     <description lang="en">New generation ProAudio overlay</description>
     <homepage>https://github.com/domichel/proaudio-gentoo</homepage>


### PR DESCRIPTION
Add the external Gentoo overlay for Precizer, a lightweight file integrity verification and comparison tool.