### PR TITLE
repositories: update overlay-of-FreshCrz source URL

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3310,7 +3310,7 @@
   <repo quality="experimental" status="unofficial">
     <name>overlay-of-FreshCrz</name>
     <description lang="en">Personal overlay</description>
-    <homepage>https://github.com/Papagemabodi/overlay-of-FreshCrz</homepage>
+    <homepage>https://gitlab.com/Papagemabodi/overlay-of-FreshCrz</homepage>
     <owner type="person">
       <email>yarikplaystryapishko@gmail.com</email>
       <name>Yaroslav Tryapishko</name>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3315,8 +3315,8 @@
       <email>yarikplaystryapishko@gmail.com</email>
       <name>Yaroslav Tryapishko</name>
     </owner>
-    <source type="git">https://github.com/Papagemabodi/overlay-of-FreshCrz.git</source>
-    <feed>https://github.com/Papagemabodi/overlay-of-FreshCrz/commits/master.atom</feed>
+    <source type="git">https://gitlab.com/Papagemabodi/overlay-of-FreshCrz.git</source>
+    <feed>https://gitlab.com/Papagemabodi/overlay-of-FreshCrz/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>overseerr-overlay</name>


### PR DESCRIPTION
Migrated overlay-of-FreshCrz from GitHub to GitLab.