### PR TITLE
repositories: add baar-dau

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -503,6 +503,18 @@
     <source type="git">https://gitlab.awesome-it.de/overlays/awesome.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>baar-dau</name>
+    <description lang="en">A personal catch-all for software the main tree ships too old or not at all.</description>
+    <homepage>https://github.com/Putrefalcis/baar-dau</homepage>
+    <owner type="person">
+      <email>the.telvanni@gmail.com</email>
+      <name>Putrefalcis</name>
+    </owner>
+    <source type="git">https://github.com/Putrefalcis/baar-dau.git</source>
+    <source type="git">git@github.com:Putrefalcis/baar-dau.git</source>
+    <feed>https://github.com/Putrefalcis/baar-dau/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>barnowl</name>
     <description lang="en">BarnOwl IM client</description>
     <homepage>https://github.com/wthrowe/barnowl-overlay</homepage>


### PR DESCRIPTION
Adds my personal overlay baar-dau. git+https on the main branch, masters=gentoo, owner email registered at bugs.gentoo.org. `make check` passes locally.