### PR TITLE
repositories: add mu-cow-overlay

### DIFF
--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -3007,6 +3007,18 @@
     <source type="git">git://anongit.gentoo.org/proj/multilib-portage.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>mu-cow-overlay</name>
+    <description lang="en">Overlay hosting mu, a minimal privilege escalation runner</description>
+    <homepage>https://github.com/MulpinKR/mu-cow-overlay</homepage>
+    <owner type="person">
+      <email>derkaca751@gmail.com</email>
+      <name>MulpinKR</name>
+    </owner>
+    <source type="git">https://github.com/MulpinKR/mu-cow-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/MulpinKR/mu-cow-overlay.git</source>
+    <feed>https://github.com/MulpinKR/mu-cow-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>mv</name>
     <description>Ebuilds for packages not in the Gentoo tree
         (lack of maintainer or too experimental) and live ebuilds

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -2997,16 +2997,6 @@
     <feed>https://gitlab.com/mselimyavuz/mselimyavuz-overlay/-/commits/main?format=atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
-    <name>multilib-portage</name>
-    <description>multilib-overlay: emul-linux-x86 must die ;)</description>
-    <homepage>https://cgit.gentoo.org/proj/multilib-portage.git/</homepage>
-    <owner type="person">
-      <email>tommy@gentoo.org</email>
-      <name>Thomas Sachau</name>
-    </owner>
-    <source type="git">git://anongit.gentoo.org/proj/multilib-portage.git</source>
-  </repo>
-  <repo quality="experimental" status="unofficial">
     <name>mu-cow-overlay</name>
     <description lang="en">Overlay hosting mu, a minimal privilege escalation runner</description>
     <homepage>https://github.com/MulpinKR/mu-cow-overlay</homepage>
@@ -3017,6 +3007,16 @@
     <source type="git">https://github.com/MulpinKR/mu-cow-overlay.git</source>
     <source type="git">git+ssh://git@github.com/MulpinKR/mu-cow-overlay.git</source>
     <feed>https://github.com/MulpinKR/mu-cow-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
+    <name>multilib-portage</name>
+    <description>multilib-overlay: emul-linux-x86 must die ;)</description>
+    <homepage>https://cgit.gentoo.org/proj/multilib-portage.git/</homepage>
+    <owner type="person">
+      <email>tommy@gentoo.org</email>
+      <name>Thomas Sachau</name>
+    </owner>
+    <source type="git">git://anongit.gentoo.org/proj/multilib-portage.git</source>
   </repo>
   <repo quality="experimental" status="unofficial">
     <name>mv</name>


### PR DESCRIPTION
Add the mu-cow-overlay repository to the overlay registry.

- Repository name: mu-cow-overlay (matches profiles/repo_name)
- Homepage: https://github.com/MulpinKR/mu-cow-overlay
- Owner: MulpinKR (derkaca751@gmail.com, Bugzilla account verified)
- Sync: git+https from GitHub, branch main