### PR TITLE
repositories: add asusctl-gentoo-overlay

### DIFF
--- a/files/mirrors/distfiles.xml
+++ b/files/mirrors/distfiles.xml
@@ -635,6 +635,11 @@ vim: ft=xml et ts=2 sts=2 sw=2:
       <uri protocol="https" ipv4="y" ipv6="y" partial="n">https://mirror.wheel.sk/gentoo</uri>
       <uri protocol="http" ipv4="y" ipv6="y" partial="n">http://mirror.wheel.sk/gentoo</uri>
     </mirror>
+    <mirror>
+      <name>Rainside.sk</name>
+      <uri protocol="http" ipv4="y" ipv6="n" partial="n">http://tux.rainside.sk/gentoo/</uri>
+      <uri protocol="ftp" ipv4="y" ipv6="n" partial="n">ftp://tux.rainside.sk/gentoo/</uri>
+    </mirror>
   </mirrorgroup>
   <mirrorgroup region="Europe" country="ES" countryname="Spain">
     <mirror>

--- a/files/overlays/repositories.xml
+++ b/files/overlays/repositories.xml
@@ -479,6 +479,18 @@
     <feed>https://github.com/kellermanrivero/asus-vivobook-16-overlay/commits/master.atom</feed>
   </repo>
   <repo quality="experimental" status="unofficial">
+    <name>asusctl-gentoo-overlay</name>
+    <description lang="en">Gentoo overlay for asusctl on ASUS Linux laptops, tested on ASUS ProArt P16 H7606WX.</description>
+    <homepage>https://github.com/reckor-usa/asusctl-gentoo-overlay</homepage>
+    <owner type="person">
+      <email>reckor-usa@pm.me</email>
+      <name>MM</name>
+    </owner>
+    <source type="git">https://github.com/reckor-usa/asusctl-gentoo-overlay.git</source>
+    <source type="git">git+ssh://git@github.com/reckor-usa/asusctl-gentoo-overlay.git</source>
+    <feed>https://github.com/reckor-usa/asusctl-gentoo-overlay/commits/main.atom</feed>
+  </repo>
+  <repo quality="experimental" status="unofficial">
     <name>audio-overlay</name>
     <description lang="en">Pro audio overlay. Please file bugs or package suggestions at https://github.com/gentoo-audio/audio-overlay/issues/new</description>
     <homepage>https://github.com/gentoo-audio/audio-overlay</homepage>


### PR DESCRIPTION
Add `asusctl-gentoo-overlay` to the Gentoo overlay registry.

Overlay:

- Repository: https://github.com/reckor-usa/asusctl-gentoo-overlay
- Package: `sys-power/asusctl`
- Current version: `6.4.0`
- Scope: ASUS Linux `asusctl` overlay, tested on ASUS ProArt P16 H7606WX
- Status: unofficial / experimental

Validation performed on the overlay:

- `pkgcheck scan --net`: clean
- `emerge -pv =sys-power/asusctl-6.4.0::asusctl-gentoo-overlay`: resolver OK
- `ebuild sys-power/asusctl/asusctl-6.4.0.ebuild clean compile install`: PASS as root
- GitHub release asset for vendored Rust dependencies fetched and checksum verified
- `repositories.xml` parsed successfully with Python `xml.etree.ElementTree`
- Entry inserted alphabetically between `asus-vivobook-16-snapdragon-x` and `audio-overlay`